### PR TITLE
Add basic pyproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# auto-generated version file
+src/astro_image_display_api/_version.py
+
 # C extensions
 *.so
 
@@ -25,6 +28,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,51 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "astro-image-display-api"
+dynamic = ["version"]
+description = 'Astronomical image display API definition for cross-backend interoperability'
+readme = "README.md"
+requires-python = ">=3.11"
+license = "BSD-3-Clause"
+keywords = []
+authors = [
+  { name = "Matt Craig", email = "mattwcraig@gmail.com" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = []
+
+[project.urls]
+Documentation = "https://github.com/astropy/astro-image-display-api#readme"
+Issues = "https://github.com/astropy/astro-image-display-api/issues"
+Source = "https://github.com/astropy/astro-image-display-api"
+
+[tool.hatch.version]
+path = "src/astro_image_display_api/__about__.py"
+
+[tool.coverage.run]
+source_pkgs = ["astro_image_display_api", "tests"]
+branch = true
+parallel = true
+omit = [
+  "src/astro_image_display_api/__about__.py",
+]
+
+[tool.coverage.paths]
+astro_image_display_api = ["src/astro_image_display_api", "*/astro-image-display-api/src/astro_image_display_api"]
+tests = ["tests", "*/astro-image-display-api/tests"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "astro-image-display-api"
 dynamic = ["version"]
 description = 'Astronomical image display API definition for cross-backend interoperability'
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = "BSD-3-Clause"
 keywords = []
 authors = [
@@ -16,10 +16,9 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
-  "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = []
 
@@ -38,9 +37,6 @@ version-file = "src/astro_image_display_api/_version.py"
 source_pkgs = ["astro_image_display_api", "tests"]
 branch = true
 parallel = true
-omit = [
-  "src/astro_image_display_api/__about__.py",
-]
 
 [tool.coverage.paths]
 astro_image_display_api = ["src/astro_image_display_api", "*/astro-image-display-api/src/astro_image_display_api"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ omit = [
 
 [tool.coverage.paths]
 astro_image_display_api = ["src/astro_image_display_api", "*/astro-image-display-api/src/astro_image_display_api"]
-tests = ["tests", "*/astro-image-display-api/tests"]
+tests = ["tests"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -29,7 +29,10 @@ Issues = "https://github.com/astropy/astro-image-display-api/issues"
 Source = "https://github.com/astropy/astro-image-display-api"
 
 [tool.hatch.version]
-path = "src/astro_image_display_api/__about__.py"
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/astro_image_display_api/_version.py"
 
 [tool.coverage.run]
 source_pkgs = ["astro_image_display_api", "tests"]

--- a/src/astro_image_display_api/__about__.py
+++ b/src/astro_image_display_api/__about__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2025-present Matt Craig <mattwcraig@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+__version__ = "0.0.1"

--- a/src/astro_image_display_api/__about__.py
+++ b/src/astro_image_display_api/__about__.py
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: 2025-present Matt Craig <mattwcraig@gmail.com>
-#
-# SPDX-License-Identifier: MIT
-__version__ = "0.0.1"


### PR DESCRIPTION
I've already added the array API in `inteface_definition.py` and the tests a backend runs to ensure it is compliant with the API in `widget_api_tests.py`.

I've set this up as a "new-style" package with a `src` and a `tests` directory but I can change that if you want.