### PR TITLE
Fix api test issues

### DIFF
--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -70,9 +70,12 @@ class ImageWidgetAPITest:
         assert self.image.image_width == width
         assert self.image.image_height == height
 
-    def test_load_fits(self, data):
+    def test_load_fits(self, data, tmp_path):
         hdu = fits.PrimaryHDU(data=data)
-        self.image.load_fits(hdu)
+        image_path = tmp_path / 'test.fits'
+        hdu.header["BUNIT"] = "adu"
+        hdu.writeto(image_path)
+        self.image.load_fits(image_path)
 
     def test_load_nddata(self, data):
         nddata = NDData(data)

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -363,6 +363,7 @@ class ImageWidgetAPITest:
         self.image.cuts = (10, 100)
         assert self.image.cuts == (10, 100)
 
+    @pytest.mark.xfail(reason="Not clear whether colormap is part of the API")
     def test_colormap(self):
         cmap_desired = 'gray'
         cmap_list = self.image.colormap_options

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -99,11 +99,11 @@ class ImageWidgetAPITest:
         self.image.offset_by(10 * u.arcmin, 10 * u.arcmin)
 
         # A mix of pixel and sky should produce an error
-        with pytest.raises(ValueError, match='but dy is of type'):
+        with pytest.raises(u.UnitConversionError, match='are not convertible'):
             self.image.offset_by(10 * u.arcmin, 10)
 
         # A mix of inconsistent units should produce an error
-        with pytest.raises(u.UnitConversionError):
+        with pytest.raises(u.UnitConversionError, match='are not convertible'):
             self.image.offset_by(1 * u.arcsec, 1 * u.AA)
 
     def test_zoom_level(self, data):

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -54,6 +54,14 @@ class ImageWidgetAPITest:
         assert len(table) == 0
         assert sorted(table.colnames) == sorted(['x', 'y', 'coord', 'marker name'])
 
+    def _get_marker_names_as_set(self):
+        marks = self.image.get_markers(marker_name="all")["marker name"]
+        if hasattr(marks, 'mask') and all(marks.mask):
+            marker_names = set()
+        else:
+            marker_names = set(marks)
+        return marker_names
+
     def test_default_marker_names(self):
         # Check only that default names are set to a non-empty string
         assert self.image.DEFAULT_MARKER_NAME

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -49,7 +49,7 @@ class ImageWidgetAPITest:
         """
         self.image = self.image_widget_class(image_width=250, image_height=100)
 
-    def _check_marker_table_return_properties(self, table):
+    def _check_empty_marker_table_return_properties(self, table):
         assert isinstance(table, Table)
         assert len(table) == 0
         assert sorted(table.colnames) == sorted(['x', 'y', 'coord', 'marker name'])
@@ -119,7 +119,7 @@ class ImageWidgetAPITest:
 
     def test_marking_operations(self):
         marks = self.image.get_markers(marker_name="all")
-        self._check_marker_table_return_properties(marks)
+        self._check_empty_marker_table_return_properties(marks)
         assert not self.image.is_marking
 
         # Ensure you cannot set it like this.
@@ -160,7 +160,7 @@ class ImageWidgetAPITest:
             warnings.simplefilter("error")
             t = self.image.get_markers(marker_name='markymark')
 
-        self._check_marker_table_return_properties(t)
+        self._check_empty_marker_table_return_properties(t)
 
         self.image.click_drag = True
         self.image.start_marking()
@@ -177,7 +177,7 @@ class ImageWidgetAPITest:
         self.image.stop_marking(clear_markers=True)
 
         assert self.image.is_marking is False
-        self._check_marker_table_return_properties(self.image.get_markers(marker_name="all"))
+        self._check_empty_marker_table_return_properties(self.image.get_markers(marker_name="all"))
 
         # Hate this, should add to public API
         marknames = self.image._marktags
@@ -250,15 +250,15 @@ class ImageWidgetAPITest:
         self.image.reset_markers()
         marknames = self.image._marktags
         assert len(marknames) == 0
-        self._check_marker_table_return_properties(self.image.get_markers(marker_name="all"))
+        self._check_empty_marker_table_return_properties(self.image.get_markers(marker_name="all"))
         # Check that no markers remain after clearing
-        tab = self.image.get_markers(marker_name=self.image._default_mark_tag_name)
-        self._check_marker_table_return_properties(tab)
+        tab = self.image.get_markers(marker_name=self.image.DEFAULT_MARKER_NAME)
+        self._check_empty_marker_table_return_properties(tab)
 
         # Check that retrieving a marker set that doesn't exist returns
         # an empty table with the right columns
         tab = self.image.get_markers(marker_name='test1')
-        self._check_marker_table_return_properties(tab)
+        self._check_empty_marker_table_return_properties(tab)
 
     def test_get_markers_accepts_list_of_names(self):
         # Check that the get_markers method accepts a list of marker names
@@ -288,7 +288,7 @@ class ImageWidgetAPITest:
         self.image.add_markers(tab, marker_name='test2')
 
         self.image.remove_markers(marker_name='all')
-        self._check_marker_table_return_properties(self.image.get_markers(marker_name='all'))
+        self._check_empty_marker_table_return_properties(self.image.get_markers(marker_name='all'))
 
     def test_remove_marker_accepts_list(self):
         data = np.arange(10).reshape(5, 2)
@@ -298,7 +298,7 @@ class ImageWidgetAPITest:
 
         self.image.remove_markers(marker_name=['test1', 'test2'])
         marks = self.image.get_markers(marker_name='all')
-        self._check_marker_table_return_properties(marks)
+        self._check_empty_marker_table_return_properties(marks)
 
     def test_adding_markers_as_world(self, data, wcs):
         ndd = NDData(data=data, wcs=wcs)

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -142,6 +142,7 @@ class ImageWidgetAPITest:
 
         # Set the marker style
         marker_style = {'color': 'yellow', 'radius': 10, 'type': 'cross'}
+        self.image.marker = marker_style
         m_str = str(self.image.marker)
         for key in marker_style.keys():
             assert key in m_str
@@ -314,14 +315,13 @@ class ImageWidgetAPITest:
         # Add markers using world coordinates
         pixels = np.linspace(0, 100, num=10).reshape(5, 2)
         marks_pix = Table(data=pixels, names=['x', 'y'], dtype=('float', 'float'))
-        marks_world = wcs.pixel_to_world(marks_pix['x'], marks_pix['y'])
-        marks_coords = SkyCoord(marks_world, unit='degree')
+        marks_coords = wcs.pixel_to_world(marks_pix['x'], marks_pix['y'])
         mark_coord_table = Table(data=[marks_coords], names=['coord'])
         self.image.add_markers(mark_coord_table, use_skycoord=True)
         result = self.image.get_markers()
         # Check the x, y positions as long as we are testing things...
         # The first test had one entry that was zero, so any check
-        # based on rtol will will. Added a small atol to make sure
+        # based on rtol will not work. Added a small atol to make sure
         # the test passes.
         np.testing.assert_allclose(result['x'], marks_pix['x'], atol=1e-9)
         np.testing.assert_allclose(result['y'], marks_pix['y'])
@@ -336,7 +336,7 @@ class ImageWidgetAPITest:
 
         original_stretch = self.image.stretch
 
-        with pytest.raises(ValueError, match='must be one of'):
+        with pytest.raises(ValueError, match='[mM]ust be one of'):
             self.image.stretch = 'not a valid value'
 
         # A bad value should leave the stretch unchanged
@@ -347,7 +347,7 @@ class ImageWidgetAPITest:
         assert self.image.stretch is not original_stretch
 
     def test_cuts(self, data):
-        with pytest.raises(ValueError, match='must be one of'):
+        with pytest.raises(ValueError, match='[mM]ust be one of'):
             self.image.cuts = 'not a valid value'
 
         with pytest.raises(ValueError, match='must have length 2'):

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -49,7 +49,7 @@ class ImageWidgetAPITest:
         """
         self.image = self.image_widget_class(image_width=250, image_height=100)
 
-    def _check_empty_marker_table_return_properties(self, table):
+    def _assert_empty_marker_table(self, table):
         assert isinstance(table, Table)
         assert len(table) == 0
         assert sorted(table.colnames) == sorted(['x', 'y', 'coord', 'marker name'])
@@ -127,7 +127,7 @@ class ImageWidgetAPITest:
 
     def test_marking_operations(self):
         marks = self.image.get_markers(marker_name="all")
-        self._check_empty_marker_table_return_properties(marks)
+        self._assert_empty_marker_table(marks)
         assert not self.image.is_marking
 
         # Ensure you cannot set it like this.
@@ -169,7 +169,7 @@ class ImageWidgetAPITest:
             warnings.simplefilter("error")
             t = self.image.get_markers(marker_name='markymark')
 
-        self._check_empty_marker_table_return_properties(t)
+        self._assert_empty_marker_table(t)
 
         self.image.click_drag = True
         self.image.start_marking()
@@ -186,7 +186,7 @@ class ImageWidgetAPITest:
         self.image.stop_marking(clear_markers=True)
 
         assert self.image.is_marking is False
-        self._check_empty_marker_table_return_properties(self.image.get_markers(marker_name="all"))
+        self._assert_empty_marker_table(self.image.get_markers(marker_name="all"))
 
         # Hate this, should add to public API
         marknames = self._get_marker_names_as_set()
@@ -258,15 +258,15 @@ class ImageWidgetAPITest:
         self.image.reset_markers()
         marknames = self._get_marker_names_as_set()
         assert len(marknames) == 0
-        self._check_empty_marker_table_return_properties(self.image.get_markers(marker_name="all"))
+        self._assert_empty_marker_table(self.image.get_markers(marker_name="all"))
         # Check that no markers remain after clearing
         tab = self.image.get_markers(marker_name=self.image.DEFAULT_MARKER_NAME)
-        self._check_empty_marker_table_return_properties(tab)
+        self._assert_empty_marker_table(tab)
 
         # Check that retrieving a marker set that doesn't exist returns
         # an empty table with the right columns
         tab = self.image.get_markers(marker_name='test1')
-        self._check_empty_marker_table_return_properties(tab)
+        self._assert_empty_marker_table(tab)
 
     def test_get_markers_accepts_list_of_names(self):
         # Check that the get_markers method accepts a list of marker names
@@ -296,7 +296,7 @@ class ImageWidgetAPITest:
         self.image.add_markers(tab, marker_name='test2')
 
         self.image.remove_markers(marker_name='all')
-        self._check_empty_marker_table_return_properties(self.image.get_markers(marker_name='all'))
+        self._assert_empty_marker_table(self.image.get_markers(marker_name='all'))
 
     def test_remove_marker_accepts_list(self):
         data = np.arange(10).reshape(5, 2)
@@ -306,7 +306,7 @@ class ImageWidgetAPITest:
 
         self.image.remove_markers(marker_name=['test1', 'test2'])
         marks = self.image.get_markers(marker_name='all')
-        self._check_empty_marker_table_return_properties(marks)
+        self._assert_empty_marker_table(marks)
 
     def test_adding_markers_as_world(self, data, wcs):
         ndd = NDData(data=data, wcs=wcs)


### PR DESCRIPTION
It turns out that there were a number of issues in the file that downstream packages would use to test API compatibility. This PR fixes them and marks one as `xfail` that tests colormaps. 