### PR TITLE
Remove settings that controlled interactivity in UI

### DIFF
--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -22,9 +22,6 @@ class ImageViewer:
     # These are attributes, not methods. The type annotations are there
     # to make sure Protocol knows they are attributes. Python does not
     # do any checking at all of these types.
-    _click_center: bool = False
-    _click_drag: bool = True
-    scroll_pan: bool = False
     image_width: int = 0
     image_height: int = 0
     zoom_level: float = 1
@@ -47,31 +44,10 @@ class ImageViewer:
 
     # some internal variable for keeping track of viewer state
     _interactive_marker_name: str = ""
-    _previous_click_center: bool = False
-    _previous_click_drag: bool = True
-    _previous_scroll_pan: bool = False
     _previous_marker: Any = ""
     _markers: dict[str, Table] = field(default_factory=dict)
     _wcs: WCS | None = None
     _center: tuple[float, float] = (0.0, 0.0)
-
-    # Some properties where we need to control what happens
-    @property
-    def click_center(self) -> bool:
-        return self._click_center
-
-    @click_center.setter
-    def click_center(self, value: bool) -> None:
-        self._click_center = value
-        self._click_drag = not value
-
-    @property
-    def click_drag(self) -> bool:
-        return self._click_drag
-    @click_drag.setter
-    def click_drag(self, value: bool) -> None:
-        self._click_drag = value
-        self._click_center = not value
 
     @property
     def stretch(self) -> str:

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -27,9 +27,6 @@ class ImageViewerInterface(Protocol):
     # These are attributes, not methods. The type annotations are there
     # to make sure Protocol knows they are attributes. Python does not
     # do any checking at all of these types.
-    click_center: bool
-    click_drag: bool
-    scroll_pan: bool
     image_width: int
     image_height: int
     zoom_level: float

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -315,42 +315,6 @@ class ImageWidgetAPITest:
         self.image.cursor = 'bottom'
         assert self.image.cursor == 'bottom'
 
-    def test_click_drag(self):
-        # Set this to ensure that click_drag turns it off
-        self.image.click_center = True
-
-        # Make sure that setting click_drag to False does not turn off
-        # click_center.
-        self.image.click_drag = False
-        assert self.image.click_center
-
-        self.image.click_drag = True
-        assert not self.image.click_center
-
-        # If is_marking is true then trying to enable click_drag should fail
-        self.image.click_drag = False
-
-    def test_click_center(self):
-        # Set this to ensure that click_center turns it off
-        self.image.click_drag = True
-
-        # Make sure that setting click_center to False does not turn off
-        # click_drag.
-        self.image.click_center = False
-        assert self.image.click_drag
-
-        self.image.click_center = True
-        assert not self.image.click_drag
-
-        self.image.click_center = False
-
-
-    def test_scroll_pan(self):
-        # Make sure scroll_pan is actually settable
-        for value in [True, False]:
-            self.image.scroll_pan = value
-            assert self.image.scroll_pan is value
-
     def test_save(self, tmp_path):
         filename = tmp_path / 'woot.png'
         self.image.save(filename)


### PR DESCRIPTION
Specifically, take out scroll_pan, click_drag, and click_center are removed as they are the responsibility of the backend.