### PR TITLE
Update allowed input types for stretch and cuts

### DIFF
--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -8,7 +8,7 @@ from astropy.nddata import CCDData, NDData
 from astropy.table import Table, vstack
 from astropy.units import Quantity, get_physical_type
 from astropy.wcs import WCS
-from astropy.visualization import BaseInterval, BaseStretch, ManualInterval
+from astropy.visualization import AsymmetricPercentileInterval, BaseInterval, BaseStretch, LinearStretch, ManualInterval
 from numpy.typing import ArrayLike
 
 from .interface_definition import ImageViewerInterface
@@ -28,8 +28,8 @@ class ImageViewer:
     zoom_level: float = 1
     _cursor: str = ImageViewerInterface.ALLOWED_CURSOR_LOCATIONS[0]
     marker: Any = "marker"
-    _cuts: str | tuple[float, float] = (0, 1)
-    _stretch: str = "linear"
+    _cuts: BaseInterval | tuple[float, float] = AsymmetricPercentileInterval(upper_percentile=95)
+    _stretch: BaseStretch = LinearStretch
     # viewer: Any
 
     # Allowed locations for cursor display
@@ -48,29 +48,24 @@ class ImageViewer:
     _wcs: WCS | None = None
     _center: tuple[float, float] = (0.0, 0.0)
 
-    @property
-    def stretch(self) -> BaseStretch:
+    def get_stretch(self) -> BaseStretch:
         return self._stretch
 
-    @stretch.setter
-    def stretch(self, value: BaseStretch) -> None:
+    def set_stretch(self, value: BaseStretch) -> None:
         if not isinstance(value, BaseStretch):
             raise ValueError(f"Stretch option {value} is not valid. Must be an Astropy.visualization Stretch object.")
         self._stretch = value
 
-    @property
-    def cuts(self) -> tuple:
+    def get_cuts(self) -> tuple:
         return self._cuts
 
-    @cuts.setter
-    def cuts(self, value: tuple) -> None:
+    def set_cuts(self, value: tuple[float, float] | BaseInterval) -> None:
         if isinstance(value, tuple) and len(value) == 2:
             self._cuts = ManualInterval(value[0], value[1])
         elif isinstance(value, BaseInterval):
             self._cuts = value
         else:
             raise ValueError("Cuts must be an Astropy.visualization Interval object or a tuple of two values.")
-
 
     @property
     def cursor(self) -> str:

--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -26,8 +26,6 @@ class ImageViewer:
     image_width: int = 0
     image_height: int = 0
     zoom_level: float = 1
-    stretch_options: tuple = ("linear", "log", "sqrt")
-    autocut_options: tuple = ("minmax", "zscale", "asinh", "percentile", "histogram")
     _cursor: str = ImageViewerInterface.ALLOWED_CURSOR_LOCATIONS[0]
     marker: Any = "marker"
     _cuts: str | tuple[float, float] = (0, 1)
@@ -57,7 +55,7 @@ class ImageViewer:
     @stretch.setter
     def stretch(self, value: BaseStretch) -> None:
         if not isinstance(value, BaseStretch):
-            raise ValueError(f"Stretch option {value} is not valid. Must be one of {self.stretch_options}.")
+            raise ValueError(f"Stretch option {value} is not valid. Must be an Astropy.visualization Stretch object.")
         self._stretch = value
 
     @property

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -33,9 +33,6 @@ class ImageViewerInterface(Protocol):
     zoom_level: float
     cursor: str
     marker: Any
-    cuts: tuple | BaseInterval
-    stretch: BaseStretch
-    # viewer: Any
 
     # Allowed locations for cursor display
     ALLOWED_CURSOR_LOCATIONS: tuple = ALLOWED_CURSOR_LOCATIONS
@@ -61,6 +58,58 @@ class ImageViewerInterface(Protocol):
         data : Any
             The data to load. This can be a FITS file, a 2D array,
             or an `astropy.nddata.NDData` object.
+        """
+        raise NotImplementedError
+
+    # Setting and getting image properties
+    @abstractmethod
+    def set_cuts(self, cuts: tuple | BaseInterval) -> None:
+        """
+        Set the cuts for the image.
+
+        Parameters
+        ----------
+        cuts : tuple or any Interval from `astropy.visualization`
+            The cuts to set. If a tuple, it should be of the form
+            ``(min, max)`` and will be interpreted as a
+            `~astropy.visualization.ManualInterval`.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_cuts(self) -> BaseInterval:
+        """
+        Get the current cuts for the image.
+
+        Returns
+        -------
+        cuts : `~astropy.visualization.BaseInterval`
+            The Astropy interval object representing the current cuts.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_stretch(self, stretch: BaseStretch) -> None:
+        """
+        Set the stretch for the image.
+
+        Parameters
+        ----------
+        stretch : Any stretch from `~astropy.visualization`
+            The stretch to set. This can be any subclass of
+            `~astropy.visualization.BaseStretch`.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_stretch(self) -> BaseStretch:
+        """
+        Get the current stretch for the image.
+
+        Returns
+        -------
+        stretch : `~astropy.visualization.BaseStretch`
+            The Astropy stretch object representing the current stretch.
         """
         raise NotImplementedError
 

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -31,8 +31,6 @@ class ImageViewerInterface(Protocol):
     image_width: int
     image_height: int
     zoom_level: float
-    stretch_options: tuple
-    autocut_options: tuple
     cursor: str
     marker: Any
     cuts: tuple | BaseInterval

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -6,6 +6,7 @@ from astropy.coordinates import SkyCoord
 from astropy.nddata import NDData
 from astropy.table import Table
 from astropy.units import Quantity
+from astropy.visualization import BaseInterval, BaseStretch
 
 from numpy.typing import ArrayLike
 
@@ -34,8 +35,8 @@ class ImageViewerInterface(Protocol):
     autocut_options: tuple
     cursor: str
     marker: Any
-    cuts: Any
-    stretch: str
+    cuts: tuple | BaseInterval
+    stretch: BaseStretch
     # viewer: Any
 
     # Allowed locations for cursor display

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -269,12 +269,9 @@ class ImageWidgetAPITest:
                                    mark_coord_table['coord'].dec.deg)
 
     def test_stretch(self):
-        # Check that the stretch options is not an empty list
-        assert len(self.image.stretch_options) > 0
-
         original_stretch = self.image.stretch
 
-        with pytest.raises(ValueError, match='[mM]ust be one of'):
+        with pytest.raises(ValueError, match=r'Stretch.*not valid.*'):
             self.image.stretch = 'not a valid value'
 
         # A bad value should leave the stretch unchanged
@@ -286,7 +283,6 @@ class ImageWidgetAPITest:
         assert isinstance(self.image.stretch, LogStretch)
 
     def test_cuts(self, data):
-        assert len(self.image.autocut_options) > 0
         with pytest.raises(ValueError, match='[mM]ust be'):
             self.image.cuts = 'not a valid value'
 

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -269,34 +269,34 @@ class ImageWidgetAPITest:
                                    mark_coord_table['coord'].dec.deg)
 
     def test_stretch(self):
-        original_stretch = self.image.stretch
+        original_stretch = self.image.get_stretch()
 
         with pytest.raises(ValueError, match=r'Stretch.*not valid.*'):
-            self.image.stretch = 'not a valid value'
+            self.image.set_stretch('not a valid value')
 
         # A bad value should leave the stretch unchanged
-        assert self.image.stretch is original_stretch
+        assert self.image.get_stretch() is original_stretch
 
-        self.image.stretch = LogStretch()
+        self.image.set_stretch(LogStretch())
         # A valid value should change the stretch
-        assert self.image.stretch is not original_stretch
-        assert isinstance(self.image.stretch, LogStretch)
+        assert self.image.get_stretch() is not original_stretch
+        assert isinstance(self.image.get_stretch(), LogStretch)
 
     def test_cuts(self, data):
         with pytest.raises(ValueError, match='[mM]ust be'):
-            self.image.cuts = 'not a valid value'
+            self.image.set_cuts('not a valid value')
 
         with pytest.raises(ValueError, match='[mM]ust be'):
-            self.image.cuts = (1, 10, 100)
+            self.image.set_cuts((1, 10, 100))
 
         # Setting using histogram requires data
         self.image.load_image(data)
-        self.image.cuts = AsymmetricPercentileInterval(0.1, 99.9)
-        assert isinstance(self.image.cuts, AsymmetricPercentileInterval)
+        self.image.set_cuts(AsymmetricPercentileInterval(0.1, 99.9))
+        assert isinstance(self.image.get_cuts(), AsymmetricPercentileInterval)
 
-        self.image.cuts = (10, 100)
-        assert isinstance(self.image.cuts, ManualInterval)
-        assert self.image.cuts.get_limits(data) == (10, 100)
+        self.image.set_cuts((10, 100))
+        assert isinstance(self.image.get_cuts(), ManualInterval)
+        assert self.image.get_cuts().get_limits(data) == (10, 100)
 
     @pytest.mark.skip(reason="Not clear whether colormap is part of the API")
     def test_colormap(self):


### PR DESCRIPTION
This implements all of the API changes related to stretch and cuts agreed to at STScI *except* adding `data_label`. I'm planning to add that everywhere it is needed in one PR.