### PR TITLE
Implement catalog part of AIDA

### DIFF
--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -365,7 +365,7 @@ class ImageViewer:
         try:
             del self._catalogs[catalog_label]
         except KeyError:
-            raise ValueError(f"Marker name {catalog_label} not found.")
+            raise ValueError(f"Catalog label {catalog_label} not found.")
 
     def get_catalog(self, x_colname: str = 'x', y_colname: str = 'y',
                     skycoord_colname: str = 'coord',

--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -171,20 +171,17 @@ class ImageViewer:
         **kwargs
             Additional keyword arguments to pass to the marker style.
         """
-        shape = shape
-        color = color
-        size = size
-
         catalog_label = self._resolve_catalog_label(catalog_label)
 
         if self._catalogs[catalog_label].data is None:
             raise ValueError("Must load a catalog before setting a catalog style.")
 
-        self._catalogs[catalog_label].style = {
-            "shape": shape,
-            "color": color,
-            "size": size,
-        }
+        self._catalogs[catalog_label].style = dict(
+            shape=shape,
+            color=color,
+            size=size,
+            **kwargs
+        )
 
     # Methods for loading data
     def load_image(self, file: str | os.PathLike | ArrayLike | NDData) -> None:

--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -1,4 +1,6 @@
 import os
+from collections import defaultdict
+from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -13,6 +15,13 @@ from numpy.typing import ArrayLike
 
 from .interface_definition import ImageViewerInterface
 
+@dataclass
+class CatalogInfo:
+    """
+    A named tuple to hold information about a catalog.
+    """
+    style: dict[str, Any] = field(default_factory=dict)
+    data: Table | None = None
 
 @dataclass
 class ImageViewer:
@@ -43,7 +52,39 @@ class ImageViewer:
         # This is a dictionary of marker sets. The keys are the names of the
         # marker sets, and the values are the tables containing the markers.
         self._default_marker_style = dict(shape="circle", color="yellow", size=10)
-        self._markers[None] = self._default_marker_style.copy()
+        self._catalogs = defaultdict(CatalogInfo)
+        self._catalogs[None].data = None
+        self._catalogs[None].style = self._default_marker_style.copy()
+
+    def _user_catalog_labels(self) -> list[str]:
+        """
+        Get the user-defined catalog labels.
+        """
+        return [label for label in self._catalogs if label is not None]
+
+    def _resolve_catalog_label(self, catalog_label: str | None) -> str:
+        """
+        Figure out the catalog label if the user did not specify one. This
+        is needed so that the user gets what they expect in the simple case
+        where there is only one catalog loaded. In that case the user may
+        or may not have actually specified a catalog label.
+        """
+        user_keys = self._user_catalog_labels()
+        if catalog_label is None:
+            match len(user_keys):
+                case 0:
+                    # No user-defined catalog labels, so return the default label.
+                    catalog_label = None
+                case 1:
+                    # The user must have loaded a catalog, so return that instead of
+                    # the default label, which live in the key None.
+                    catalog_label = user_keys[0]
+                case _:
+                    raise ValueError(
+                        "Multiple catalog styles defined. Please specify a catalog_label to get the style."
+                    )
+
+        return catalog_label
 
     def get_stretch(self) -> BaseStretch:
         return self._stretch
@@ -90,22 +131,9 @@ class ImageViewer:
         dict
             The style for the catalog.
         """
-        user_keys = list(set(self._markers.keys()) - {None})
-        if catalog_label is None:
-            match len(user_keys):
-                case 0:
-                    # No user-defined styles, so return the default style
-                    catalog_label = None
-                case 1:
-                    # The user must have set a style, so return that instead of
-                    # the default style, which live in the key None.
-                    catalog_label = user_keys[0]
-                case _:
-                    raise ValueError(
-                        "Multiple catalog styles defined. Please specify a catalog_label to get the style."
-                    )
+        catalog_label = self._resolve_catalog_label(catalog_label)
 
-        style = self._markers[catalog_label]
+        style = self._catalogs[catalog_label].style
         style["catalog_label"] = catalog_label
         return style
 
@@ -137,7 +165,12 @@ class ImageViewer:
         color = color if color else self._default_marker_style["color"]
         size = size if size else self._default_marker_style["size"]
 
-        self._markers[catalog_label] = {
+        catalog_label = self._resolve_catalog_label(catalog_label)
+
+        if self._catalogs[catalog_label].data is None:
+            raise ValueError("Must load a catalog before setting a catalog style.")
+
+        self._catalogs[catalog_label].style = {
             "shape": shape,
             "color": color,
             "size": size,
@@ -240,9 +273,10 @@ class ImageViewer:
         p.write_text("This is a dummy file. The viewer does not save anything.")
 
     # Marker-related methods
-    def add_markers(self, table: Table, x_colname: str = 'x', y_colname: str = 'y',
-                    skycoord_colname: str = 'coord', use_skycoord: bool = False,
-                    marker_name: str | None = None) -> None:
+    def load_catalog(self, table: Table, x_colname: str = 'x', y_colname: str = 'y',
+                    skycoord_colname: str = 'coord', use_skycoord: bool = True,
+                    catalog_label: str | None = None,
+                    catalog_style: dict | None = None) -> None:
         """
         Add markers to the image.
 
@@ -262,8 +296,8 @@ class ImageViewer:
             is ``'coord'``.
         use_skycoord : bool, optional
             If `True`, the ``skycoord_colname`` column will be used to
-            get the marker positions. Default is `False`.
-        marker_name : str, optional
+            get the marker positions.
+        catalog_label : str, optional
             The name of the marker set to use. If not given, a unique
             name will be generated.
         """
@@ -272,105 +306,86 @@ class ImageViewer:
         except KeyError:
             coords = None
 
-        if use_skycoord:
-            if self._wcs is not None:
+        try:
+            xy = (table[x_colname], table[y_colname])
+        except KeyError:
+            xy = None
+
+        to_add = deepcopy(table)
+        if xy is None:
+            if self._wcs is not None and coords is not None:
                 x, y = self._wcs.world_to_pixel(coords)
+                to_add[x_colname] = x
+                to_add[y_colname] = y
             else:
-                raise ValueError("WCS is not set. Cannot convert to pixel coordinates.")
+                to_add[x_colname] = to_add[y_colname] = None
+
+        if coords is None:
+            if use_skycoord and self._wcs is None:
+                raise ValueError("Cannot use sky coordinates without a SkyCoord column or WCS.")
+            elif xy is not None and self._wcs is not None:
+                # If we have xy coordinates, convert them to sky coordinates
+                coords = self._wcs.pixel_to_world(xy[0], xy[1])
+                to_add[skycoord_colname] = coords
+            else:
+                to_add[skycoord_colname] = None
+
+        catalog_label = self._resolve_catalog_label(catalog_label)
+        if (
+            catalog_label in self._catalogs
+            and self._catalogs[catalog_label].data is not None
+        ):
+            old_table = self._catalogs[catalog_label].data
+            self._catalogs[catalog_label].data = vstack([old_table, to_add])
         else:
-            x = table[x_colname]
-            y = table[y_colname]
+            self._catalogs[catalog_label].data = to_add
 
-            if not coords and self._wcs is not None:
-                coords = self._wcs.pixel_to_world(x, y)
-
-        to_add = Table(
-            dict(
-                x=x,
-                y=y,
-                coord=coords if coords else [None] * len(x),
-            )
-        )
-        to_add["marker name"] = marker_name
-
-        if marker_name in self._markers:
-            marker_table = self._markers[marker_name]
-            self._markers[marker_name] = vstack([marker_table, to_add])
-        else:
-            self._markers[marker_name] = to_add
-
-    def reset_markers(self) -> None:
-        """
-        Remove all markers from the image.
-        """
-        self._markers = {}
-
-    def remove_markers(self, marker_name: str | list[str] | None = None) -> None:
+    def remove_catalog(self, catalog_label: str | None = None) -> None:
         """
         Remove markers from the image.
 
         Parameters
         ----------
         marker_name : str, optional
-            The name of the marker set to remove. If the value is ``"all"``,
+            The name of the marker set to remove. If the value is ``"*"``,
             then all markers will be removed.
         """
-        if isinstance(marker_name, str):
-            if marker_name in self._markers:
-                del self._markers[marker_name]
-            elif marker_name == "all":
-                self._markers = {}
-            else:
-                raise ValueError(f"Marker name {marker_name} not found.")
-        elif isinstance(marker_name, list):
-            for name in marker_name:
-                if name in self._markers:
-                    del self._markers[name]
-                else:
-                    raise ValueError(f"Marker name {name} not found.")
+        if isinstance(catalog_label, list):
+            raise ValueError(
+                "Cannot remove multiple catalogs from a list. Please specify "
+                "a single catalog label or use '*' to remove all catalogs."
+            )
+        elif catalog_label == "*":
+            # If the user wants to remove all catalogs, we reset the
+            # catalogs dictionary to an empty one.
+            self._catalogs = defaultdict(CatalogInfo)
+            return
 
-    def get_markers(self, x_colname: str = 'x', y_colname: str = 'y',
+        # Special cases are done, so we can resolve the catalog label
+        catalog_label = self._resolve_catalog_label(catalog_label)
+
+        try:
+            del self._catalogs[catalog_label]
+        except KeyError:
+            raise ValueError(f"Marker name {catalog_label} not found.")
+
+    def get_catalog(self, x_colname: str = 'x', y_colname: str = 'y',
                     skycoord_colname: str = 'coord',
-                    marker_name: str | list[str] | None = None) -> Table:
-        """
-        Get the marker positions.
+                    catalog_label: str | None = None) -> Table:
+        # Dostring is copied from the interface definition, so it is not
+        # duplicated here.
+        catalog_label = self._resolve_catalog_label(catalog_label)
 
-        Parameters
-        ----------
-        x_colname : str, optional
-            The name of the column containing the x positions. Default
-            is ``'x'``.
-        y_colname : str, optional
-            The name of the column containing the y positions. Default
-            is ``'y'``.
-        skycoord_colname : str, optional
-            The name of the column containing the sky coordinates. Default
-            is ``'coord'``.
-        marker_name : str or list of str, optional
-            The name of the marker set to use. If that value is ``"all"``,
-            then all markers will be returned.
+        result = self._catalogs[catalog_label].data if catalog_label in self._catalogs else Table(names=["x", "y", "coord"])
 
-        Returns
-        -------
-        table : `astropy.table.Table`
-            The table containing the marker positions. If no markers match the
-            ``marker_name`` parameter, an empty table is returned.
-        """
-        if isinstance(marker_name, str):
-            if marker_name == "all":
-                marker_name = self._markers.keys()
-            else:
-                marker_name = [marker_name]
-        elif marker_name is None:
-            marker_name = ["_default_marker"]
-
-        to_stack = [self._markers[name] for name in marker_name if name in self._markers]
-
-        result = vstack(to_stack) if to_stack else Table(names=["x", "y", "coord", "marker name"])
         result.rename_columns(["x", "y", "coord"], [x_colname, y_colname, skycoord_colname])
 
         return result
+    get_catalog.__doc__ = ImageViewerInterface.get_catalog.__doc__
 
+    def get_catalog_names(self) -> list[str]:
+        return list(self._user_catalog_labels())
+    get_catalog_names.__doc__ = ImageViewerInterface.get_catalog_names.__doc__
 
     # Methods that modify the view
     def center_on(self, point: tuple | SkyCoord):

--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -51,10 +51,9 @@ class ImageViewer:
     def __post_init__(self):
         # This is a dictionary of marker sets. The keys are the names of the
         # marker sets, and the values are the tables containing the markers.
-        self._default_marker_style = dict(shape="circle", color="yellow", size=10)
         self._catalogs = defaultdict(CatalogInfo)
         self._catalogs[None].data = None
-        self._catalogs[None].style = self._default_marker_style.copy()
+        self._catalogs[None].style = self._default_catalog_style.copy()
 
     def _user_catalog_labels(self) -> list[str]:
         """
@@ -85,6 +84,17 @@ class ImageViewer:
                     )
 
         return catalog_label
+
+    @property
+    def _default_catalog_style(self) -> dict[str, Any]:
+        """
+        The default style for the catalog markers.
+        """
+        return {
+            "shape": "circle",
+            "color": "red",
+            "size": 5,
+        }
 
     def get_stretch(self) -> BaseStretch:
         return self._stretch
@@ -117,7 +127,7 @@ class ImageViewer:
 
     # The methods, grouped loosely by purpose
 
-    def get_catalog_style(self, catalog_label=None) -> dict[str, dict[str, Any]]:
+    def get_catalog_style(self, catalog_label=None) -> dict[str, Any]:
         """
         Get the style for the catalog.
 
@@ -140,9 +150,9 @@ class ImageViewer:
     def set_catalog_style(
             self,
             catalog_label: str | None = None,
-            shape: str = "",
-            color: str = "",
-            size: float = 0,
+            shape: str = "circle",
+            color: str = "red",
+            size: float = 5,
             **kwargs
     ) -> None:
         """
@@ -161,9 +171,9 @@ class ImageViewer:
         **kwargs
             Additional keyword arguments to pass to the marker style.
         """
-        shape = shape if shape else self._default_marker_style["shape"]
-        color = color if color else self._default_marker_style["color"]
-        size = size if size else self._default_marker_style["size"]
+        shape = shape
+        color = color
+        size = size
 
         catalog_label = self._resolve_catalog_label(catalog_label)
 
@@ -174,7 +184,6 @@ class ImageViewer:
             "shape": shape,
             "color": color,
             "size": size,
-            **kwargs,
         }
 
     # Methods for loading data
@@ -308,17 +317,22 @@ class ImageViewer:
 
         catalog_label = self._resolve_catalog_label(catalog_label)
 
+        # Either set new data or append to existing data
         if (
             catalog_label in self._catalogs
             and self._catalogs[catalog_label].data is not None
         ):
+            # If the catalog already exists, we append to it
             old_table = self._catalogs[catalog_label].data
             self._catalogs[catalog_label].data = vstack([old_table, to_add])
         else:
+            # If the catalog does not exist, we create a new one
             self._catalogs[catalog_label].data = to_add
 
+        # Ensure a catalog always has a style
         if catalog_style is None:
-            catalog_style = self._default_marker_style.copy()
+            if not self._catalogs[catalog_label].style:
+                catalog_style = self._default_catalog_style.copy()
 
         self._catalogs[catalog_label].style = catalog_style
 

--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -36,7 +36,6 @@ class ImageViewer:
     image_height: int = 0
     zoom_level: float = 1
     _cursor: str = ImageViewerInterface.ALLOWED_CURSOR_LOCATIONS[0]
-    marker: Any = "marker"
     _cuts: BaseInterval | tuple[float, float] = AsymmetricPercentileInterval(upper_percentile=95)
     _stretch: BaseStretch = LinearStretch
     # viewer: Any

--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -18,7 +18,7 @@ from .interface_definition import ImageViewerInterface
 @dataclass
 class CatalogInfo:
     """
-    A named tuple to hold information about a catalog.
+    Class to hold information about a catalog.
     """
     style: dict[str, Any] = field(default_factory=dict)
     data: Table | None = None
@@ -143,7 +143,7 @@ class ImageViewer:
         """
         catalog_label = self._resolve_catalog_label(catalog_label)
 
-        style = self._catalogs[catalog_label].style
+        style = self._catalogs[catalog_label].style.copy()
         style["catalog_label"] = catalog_label
         return style
 
@@ -280,7 +280,7 @@ class ImageViewer:
 
     # Marker-related methods
     def load_catalog(self, table: Table, x_colname: str = 'x', y_colname: str = 'y',
-                    skycoord_colname: str = 'coord', use_skycoord: bool = True,
+                    skycoord_colname: str = 'coord', use_skycoord: bool = False,
                     catalog_label: str | None = None,
                     catalog_style: dict | None = None) -> None:
         try:

--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -277,30 +277,6 @@ class ImageViewer:
                     skycoord_colname: str = 'coord', use_skycoord: bool = True,
                     catalog_label: str | None = None,
                     catalog_style: dict | None = None) -> None:
-        """
-        Add markers to the image.
-
-        Parameters
-        ----------
-        table : `astropy.table.Table`
-            The table containing the marker positions.
-        x_colname : str, optional
-            The name of the column containing the x positions. Default
-            is ``'x'``.
-        y_colname : str, optional
-            The name of the column containing the y positions. Default
-            is ``'y'``.
-        skycoord_colname : str, optional
-            The name of the column containing the sky coordinates. If
-            given, the ``use_skycoord`` parameter is ignored. Default
-            is ``'coord'``.
-        use_skycoord : bool, optional
-            If `True`, the ``skycoord_colname`` column will be used to
-            get the marker positions.
-        catalog_label : str, optional
-            The name of the marker set to use. If not given, a unique
-            name will be generated.
-        """
         try:
             coords = table[skycoord_colname]
         except KeyError:
@@ -331,6 +307,7 @@ class ImageViewer:
                 to_add[skycoord_colname] = None
 
         catalog_label = self._resolve_catalog_label(catalog_label)
+
         if (
             catalog_label in self._catalogs
             and self._catalogs[catalog_label].data is not None
@@ -339,6 +316,13 @@ class ImageViewer:
             self._catalogs[catalog_label].data = vstack([old_table, to_add])
         else:
             self._catalogs[catalog_label].data = to_add
+
+        if catalog_style is None:
+            catalog_style = self._default_marker_style.copy()
+
+        self._catalogs[catalog_label].style = catalog_style
+
+    load_catalog.__doc__ = ImageViewerInterface.load_catalog.__doc__
 
     def remove_catalog(self, catalog_label: str | None = None) -> None:
         """

--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -35,12 +35,6 @@ class ImageViewer:
     # Allowed locations for cursor display
     ALLOWED_CURSOR_LOCATIONS: tuple = ImageViewerInterface.ALLOWED_CURSOR_LOCATIONS
 
-    # List of marker names that are for internal use only
-    RESERVED_MARKER_SET_NAMES: tuple = ImageViewerInterface.RESERVED_MARKER_SET_NAMES
-
-    # Default marker name for marking via API
-    DEFAULT_MARKER_NAME: str = ImageViewerInterface.DEFAULT_MARKER_NAME
-
     # some internal variable for keeping track of viewer state
     _interactive_marker_name: str = ""
     _previous_marker: Any = ""
@@ -219,11 +213,6 @@ class ImageViewer:
             if not coords and self._wcs is not None:
                 coords = self._wcs.pixel_to_world(x, y)
 
-        if marker_name in self.RESERVED_MARKER_SET_NAMES:
-            raise ValueError(f"Marker name {marker_name} not allowed.")
-
-        marker_name = marker_name if marker_name else self.DEFAULT_MARKER_NAME
-
         to_add = Table(
             dict(
                 x=x,
@@ -302,7 +291,7 @@ class ImageViewer:
             else:
                 marker_name = [marker_name]
         elif marker_name is None:
-            marker_name = [self.DEFAULT_MARKER_NAME]
+            marker_name = ["_default_marker"]
 
         to_stack = [self._markers[name] for name in marker_name if name in self._markers]
 

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -28,7 +28,6 @@ class ImageViewerInterface(Protocol):
     image_height: int
     zoom_level: float
     cursor: str
-    marker: Any
 
     # Allowed locations for cursor display
     ALLOWED_CURSOR_LOCATIONS: tuple = ALLOWED_CURSOR_LOCATIONS

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -151,7 +151,7 @@ class ImageViewerInterface(Protocol):
             name will be generated.
         catalog_style: dict, optional
             A dictionary that specifies the style of the markers used to
-            rerpresent the catalog. See `ImageViewerInterface.set_catalog_style`
+            represent the catalog. See `ImageViewerInterface.set_catalog_style`
             for details.
         """
         raise NotImplementedError

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -127,7 +127,7 @@ class ImageViewerInterface(Protocol):
                     catalog_label: str | None = None,
                     catalog_style: dict | None = None) -> None:
         """
-        Add markers to the viewer at positions given by a catalog.
+        Add catalog entries to the viewer at positions given by the catalog.
 
         Parameters
         ----------

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -151,9 +151,57 @@ class ImageViewerInterface(Protocol):
         """
         raise NotImplementedError
 
-    # @abstractmethod
-    # def remove_all_markers(self):
-    #     raise NotImplementedError
+    @abstractmethod
+    def set_catalog_style(
+        self,
+        catalog_label: str | None = None,
+        shape: str = 'circle',
+        color: str = 'red',
+        size: float = 5.0,
+        **kwargs
+    ):
+        """
+        Set the style of the catalog markers.
+
+        Parameters
+        ----------
+        shape : str, optional
+            The shape of the markers. Default is ``'circle'``. The set of
+            supported shapes is listed below in the `Notes` section.
+        color : str, optional
+            The color of the markers. Default is ``'red'``. Permitted colors are
+            any CSS4 color name. CSS4 also permits hex RGB or RGBA colors.
+        size : float, optional
+            The size of the markers. Default is ``5.0``.
+
+        **kwargs
+            Additional keyword arguments to pass to the marker style.
+
+        Notes
+        -----
+        The following shapes are supported: "circle", "square", "crosshair", "plus",
+        "diamond".
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_catalog_style(self, catalog_label: str | None = None) -> dict:
+        """
+        Get the style of the catalog markers.
+
+        Returns
+        -------
+        dict
+            The style of the markers.
+
+        Raises
+        ------
+
+        ValueError
+            If there are multiple catalog styles set and the user has not
+            specified a `catalog_label` for which to get the style.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def reset_markers(self) -> None:

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -13,10 +13,6 @@ from numpy.typing import ArrayLike
 # Allowed locations for cursor display
 ALLOWED_CURSOR_LOCATIONS = ('top', 'bottom', None)
 
-DEFAULT_MARKER_NAME = 'default-marker-name'
-
-# List of marker names that are for internal use only
-RESERVED_MARKER_SET_NAMES = ('all',)
 
 __all__ = [
     'ImageViewerInterface',
@@ -36,12 +32,6 @@ class ImageViewerInterface(Protocol):
 
     # Allowed locations for cursor display
     ALLOWED_CURSOR_LOCATIONS: tuple = ALLOWED_CURSOR_LOCATIONS
-
-    # List of marker names that are for internal use only
-    RESERVED_MARKER_SET_NAMES: tuple = RESERVED_MARKER_SET_NAMES
-
-    # Default marker name for marking via API
-    DEFAULT_MARKER_NAME: str = DEFAULT_MARKER_NAME
 
     # The methods, grouped loosely by purpose
 

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -125,9 +125,9 @@ class ImageViewerInterface(Protocol):
     def load_catalog(self, table: Table, x_colname: str = 'x', y_colname: str = 'y',
                     skycoord_colname: str = 'coord', use_skycoord: bool = False,
                     catalog_label: str | None = None,
-                    catalog_style: str | None = None) -> None:
+                    catalog_style: dict | None = None) -> None:
         """
-        Add markers to the image.
+        Add markers to the viewer at positions given by a catalog.
 
         Parameters
         ----------
@@ -149,7 +149,7 @@ class ImageViewerInterface(Protocol):
         catalog_label : str, optional
             The name of the marker set to use. If not given, a unique
             name will be generated.
-        catalog_style: str, optional
+        catalog_style: dict, optional
             A dictionary that specifies the style of the markers used to
             rerpresent the catalog. See `ImageViewerInterface.set_catalog_style`
             for details.

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -122,9 +122,10 @@ class ImageViewerInterface(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def add_markers(self, table: Table, x_colname: str = 'x', y_colname: str = 'y',
+    def load_catalog(self, table: Table, x_colname: str = 'x', y_colname: str = 'y',
                     skycoord_colname: str = 'coord', use_skycoord: bool = False,
-                    marker_name: str | None = None) -> None:
+                    catalog_label: str | None = None,
+                    catalog_style: str | None = None) -> None:
         """
         Add markers to the image.
 
@@ -145,9 +146,13 @@ class ImageViewerInterface(Protocol):
         use_skycoord : bool, optional
             If `True`, the ``skycoord_colname`` column will be used to
             get the marker positions. Default is `False`.
-        marker_name : str, optional
+        catalog_label : str, optional
             The name of the marker set to use. If not given, a unique
             name will be generated.
+        catalog_style: str, optional
+            A dictionary that specifies the style of the markers used to
+            rerpresent the catalog. See `ImageViewerInterface.set_catalog_style`
+            for details.
         """
         raise NotImplementedError
 
@@ -204,29 +209,22 @@ class ImageViewerInterface(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def reset_markers(self) -> None:
-        """
-        Remove all markers from the image.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def remove_markers(self, marker_name: str | list[str] | None = None) -> None:
+    def remove_catalog(self, catalog_label: str | list[str] | None = None) -> None:
         """
         Remove markers from the image.
 
         Parameters
         ----------
-        marker_name : str, optional
+        catalog_label : str, optional
             The name of the marker set to remove. If the value is ``"all"``,
             then all markers will be removed.
         """
         raise NotImplementedError
 
     @abstractmethod
-    def get_markers(self, x_colname: str = 'x', y_colname: str = 'y',
+    def get_catalog(self, x_colname: str = 'x', y_colname: str = 'y',
                     skycoord_colname: str = 'coord',
-                    marker_name: str | list[str] | None = None) -> Table:
+                    catalog_label: str | list[str] | None = None) -> Table:
         """
         Get the marker positions.
 
@@ -241,7 +239,7 @@ class ImageViewerInterface(Protocol):
         skycoord_colname : str, optional
             The name of the column containing the sky coordinates. Default
             is ``'coord'``.
-        marker_name : str or list of str, optional
+        catalog_label : str or list of str, optional
             The name of the marker set to use. If that value is ``"all"``,
             then all markers will be returned.
 
@@ -249,7 +247,19 @@ class ImageViewerInterface(Protocol):
         -------
         table : `astropy.table.Table`
             The table containing the marker positions. If no markers match the
-            ``marker_name`` parameter, an empty table is returned.
+            ``catalog_label`` parameter, an empty table is returned.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_catalog_names(self) -> list[str]:
+        """
+        Get the names of the loaded catalogs.
+
+        Returns
+        -------
+        list of str
+            The names of the loaded catalogs.
         """
         raise NotImplementedError
 

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -158,7 +158,7 @@ class ImageWidgetAPITest:
         self.image.load_catalog(catalog)
         # Check that setting a marker style works
         marker_settings = dict(color='red', shape='x', size=10)
-        self.image.set_catalog_style(**marker_settings)
+        self.image.set_catalog_style(**marker_settings.copy())
 
         retrieved_style = self.image.get_catalog_style()
         # Check that the marker style is set correctly
@@ -174,7 +174,7 @@ class ImageWidgetAPITest:
         self.image.load_catalog(catalog, catalog_label='test1')
         set_style_input = dict(catalog_label='test1', color='blue',
                                      shape='square', size=5)
-        self.image.set_catalog_style(**set_style_input)
+        self.image.set_catalog_style(**set_style_input.copy())
         retrieved_style = self.image.get_catalog_style()
 
         assert set_style_input == retrieved_style
@@ -368,9 +368,12 @@ class ImageWidgetAPITest:
         # for that catalog.
         style = dict(color='blue', shape='x', size=10)
         self.image.load_catalog(catalog, catalog_label='test1',
-                                catalog_style=style)
+                                catalog_style=style.copy())
 
         retrieved_style = self.image.get_catalog_style(catalog_label='test1')
+
+        # Add catalog_label to the style for comparison
+        style['catalog_label'] = 'test1'
         assert retrieved_style == style
 
     def test_remove_catalog(self):

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -339,6 +339,27 @@ class ImageWidgetAPITest:
         assert 'extra_info' in retrieved_catalog.colnames
         assert (retrieved_catalog['extra_info'] == catalog['extra_info']).all()
 
+    def test_load_catalog_with_no_style_has_a_style(self, catalog):
+        # Check that loading a catalog without a style sets a default style
+        # for that catalog.
+        self.image.load_catalog(catalog, catalog_label='test1')
+
+        retrieved_style = self.image.get_catalog_style(catalog_label='test1')
+        assert isinstance(retrieved_style, dict)
+        assert 'color' in retrieved_style
+        assert 'shape' in retrieved_style
+        assert 'size' in retrieved_style
+
+    def test_load_catalog_with_style_sets_style(self, catalog):
+        # Check that loading a catalog with a style sets the style
+        # for that catalog.
+        style = dict(color='blue', marker='x', size=10)
+        self.image.load_catalog(catalog, catalog_label='test1',
+                                catalog_style=style)
+
+        retrieved_style = self.image.get_catalog_style(catalog_label='test1')
+        assert retrieved_style == style
+
     def test_remove_catalog(self):
         with pytest.raises(ValueError, match='arf'):
             self.image.remove_catalog(catalog_label='arf')

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -192,14 +192,14 @@ class ImageWidgetAPITest:
         with pytest.raises(ValueError, match='Multiple catalog styles'):
             self.image.get_catalog_style()
 
-    def set_get_caralog_style_preserves_extra_keywords(self, catalog):
+    def test_set_get_catalog_style_preserves_extra_keywords(self, catalog):
         # Check that setting a catalog style with extra keywords preserves
         # those keywords.
         self.image.load_catalog(catalog)
         # The only required keywords are color, shape, and size.
         # Add some extra keyword to the style.
         style = dict(color='blue', shape='x', size=10, extra_kw='extra_value', alpha=0.5)
-        self.image.set_catalog_style(**style)
+        self.image.set_catalog_style(**style.copy())
 
         retrieved_style = self.image.get_catalog_style()
         del retrieved_style['catalog_label']  # Remove the label

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -61,10 +61,6 @@ class ImageWidgetAPITest:
             marker_names = set(marks)
         return marker_names
 
-    def test_default_marker_names(self):
-        # Check only that default names are set to a non-empty string
-        assert self.image.DEFAULT_MARKER_NAME
-
     def test_width_height(self):
         assert self.image.image_width == 250
         assert self.image.image_height == 100
@@ -134,15 +130,12 @@ class ImageWidgetAPITest:
             assert key in m_str
 
     def test_add_markers(self):
-        original_marker_name = self.image.DEFAULT_MARKER_NAME
         data = np.arange(10).reshape(5, 2)
         orig_tab = Table(data=data, names=['x', 'y'], dtype=('float', 'float'))
         tab = Table(data=data, names=['x', 'y'], dtype=('float', 'float'))
         self.image.add_markers(tab, x_colname='x', y_colname='y',
                                skycoord_colname='coord', marker_name='test1')
 
-        # Make sure setting didn't change the default name
-        assert self.image.DEFAULT_MARKER_NAME == original_marker_name
 
         # Regression test for GitHub Issue 45:
         # Adding markers should not modify the input data table.
@@ -176,12 +169,6 @@ class ImageWidgetAPITest:
         self.image.remove_markers(marker_name='test1')
         marknames = self._get_marker_names_as_set()
         assert marknames == set(['test2'])
-        # assert self.image.get_marker_names() == ['test2']
-
-        # Ensure unable to mark with reserved name
-        for name in self.image.RESERVED_MARKER_SET_NAMES:
-            with pytest.raises(ValueError, match='not allowed'):
-                self.image.add_markers(tab, marker_name=name)
 
         # Add markers with no marker name and check we can retrieve them
         # using the default marker name
@@ -190,7 +177,7 @@ class ImageWidgetAPITest:
         # Don't care about the order of the marker names so use set instead of
         # list.
         marknames = self._get_marker_names_as_set()
-        assert (set(marknames) == set(['test2', self.image.DEFAULT_MARKER_NAME]))
+        assert (set(marknames) == set(['test2']))
 
         # Clear markers to not pollute other tests.
         self.image.reset_markers()
@@ -198,7 +185,7 @@ class ImageWidgetAPITest:
         assert len(marknames) == 0
         self._assert_empty_marker_table(self.image.get_markers(marker_name="all"))
         # Check that no markers remain after clearing
-        tab = self.image.get_markers(marker_name=self.image.DEFAULT_MARKER_NAME)
+        tab = self.image.get_markers()
         self._assert_empty_marker_table(tab)
 
         # Check that retrieving a marker set that doesn't exist returns

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -300,7 +300,7 @@ class ImageWidgetAPITest:
     def test_load_catalog_with_skycoord_no_wcs(self, catalog, data):
         # Check that loading a catalog with skycoord but no x/y and
         # no WCS returns a catalog with None for x and y.
-        self.image.load_array(data)
+        self.image.load_image(data)
 
         # Remove x/y columns from the catalog
         del catalog['x', 'y']
@@ -315,7 +315,7 @@ class ImageWidgetAPITest:
     def test_load_catalog_with_use_skycoord_no_skycoord_no_wcs(self, catalog, data):
         # Check that loading a catalog with use_skycoord=True but no
         # skycoord column and no WCS raises an error.
-        self.image.load_array(data)
+        self.image.load_image(data)
         del catalog['coord']  # Remove the skycoord column
         with pytest.raises(ValueError, match='Cannot use sky coordinates without'):
             self.image.load_catalog(catalog, use_skycoord=True)
@@ -323,7 +323,7 @@ class ImageWidgetAPITest:
     def test_load_catalog_with_xy_and_wcs(self, catalog, data, wcs):
         # Check that loading a catalog that wants to use sky coordinates,
         # has no coordinate column but has x/y and a WCS works.
-        self.image.load_nddata(NDData(data=data, wcs=wcs))
+        self.image.load_image(NDData(data=data, wcs=wcs))
 
         # Remove the skycoord column from the catalog
         del catalog['coord']

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -121,13 +121,46 @@ class ImageWidgetAPITest:
         self.image.zoom(2)
         assert self.image.zoom_level == 6  # 3 x 2
 
-    def test_marker_properties(self):
-        # Set the marker style
-        marker_style = {'color': 'yellow', 'radius': 10, 'type': 'cross'}
-        self.image.marker = marker_style
-        m_str = str(self.image.marker)
-        for key in marker_style.keys():
-            assert key in m_str
+    def test_set_get_catalog_style_no_labels(self):
+        # Check that getting without setting returns a dict that contains
+        # the minimum required keys
+        required_style_keys = ['color', 'shape', 'size']
+        marker_style = self.image.get_catalog_style()
+        for key in required_style_keys:
+            assert key in marker_style
+
+        # Check that setting a marker style works
+        marker_settings = dict(color='red', marker='x', size=10)
+        self.image.set_catalog_style(**marker_settings)
+
+        retrieved_style = self.image.get_catalog_style()
+        # Check that the marker style is set correctly
+        for key, value in marker_settings.items():
+            assert retrieved_style[key] == value
+
+        # Check that set accepts the output of get
+        self.image.set_catalog_style(**retrieved_style)
+
+    def test_set_get_catalog_style_with_single_label(self):
+        # Check that when there is only a single catalog label it is
+        # not necessary to provide the label on get.
+        set_style_input = dict(catalog_label='test1', color='blue',
+                                     shape='square', size=5)
+        self.image.set_catalog_style(**set_style_input)
+        retrieved_style = self.image.get_catalog_style()
+
+        assert set_style_input == retrieved_style
+
+    def test_get_catalog_style_with_multiple_labels_raises_error(self):
+        # Check that when there are multiple catalog labels, the
+        # get_catalog_style method raises an error if no label is given.
+        self.image.set_catalog_style(catalog_label='test1', color='blue',
+                                     shape='square', size=5)
+        self.image.set_catalog_style(catalog_label='test2', color='red',
+                                     shape='circle', size=10)
+
+        with pytest.raises(ValueError, match='Multiple catalog styles'):
+            self.image.get_catalog_style()
 
     def test_add_markers(self):
         data = np.arange(10).reshape(5, 2)

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -143,7 +143,7 @@ class ImageWidgetAPITest:
             ValueError,
             match='Must load a catalog before setting a catalog style'
         ):
-            self.image.set_catalog_style(color='red', marker='x', size=10)
+            self.image.set_catalog_style(color='red', shape='x', size=10)
 
     def test_set_get_catalog_style_no_labels(self, catalog):
         # Check that getting without setting returns a dict that contains
@@ -157,7 +157,7 @@ class ImageWidgetAPITest:
         # Add some data before setting a style
         self.image.load_catalog(catalog)
         # Check that setting a marker style works
-        marker_settings = dict(color='red', marker='x', size=10)
+        marker_settings = dict(color='red', shape='x', size=10)
         self.image.set_catalog_style(**marker_settings)
 
         retrieved_style = self.image.get_catalog_style()
@@ -191,6 +191,19 @@ class ImageWidgetAPITest:
 
         with pytest.raises(ValueError, match='Multiple catalog styles'):
             self.image.get_catalog_style()
+
+    def set_get_caralog_style_preserves_extra_keywords(self, catalog):
+        # Check that setting a catalog style with extra keywords preserves
+        # those keywords.
+        self.image.load_catalog(catalog)
+        # The only required keywords are color, shape, and size.
+        # Add some extra keyword to the style.
+        style = dict(color='blue', shape='x', size=10, extra_kw='extra_value', alpha=0.5)
+        self.image.set_catalog_style(**style)
+
+        retrieved_style = self.image.get_catalog_style()
+        del retrieved_style['catalog_label']  # Remove the label
+        assert retrieved_style == style
 
     @pytest.mark.parametrize("catalog_label", ['test1', None])
     def test_load_get_single_catalog_with_without_label(self, catalog, catalog_label):
@@ -353,7 +366,7 @@ class ImageWidgetAPITest:
     def test_load_catalog_with_style_sets_style(self, catalog):
         # Check that loading a catalog with a style sets the style
         # for that catalog.
-        style = dict(color='blue', marker='x', size=10)
+        style = dict(color='blue', shape='x', size=10)
         self.image.load_catalog(catalog, catalog_label='test1',
                                 catalog_style=style)
 

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -137,7 +137,7 @@ class ImageWidgetAPITest:
         assert self.image.zoom_level == 6  # 3 x 2
 
     def test_set_catalog_style_before_catalog_data_raises_error(self):
-        # Make sure3 that adding a catalog style before adding any catalog
+        # Make sure that adding a catalog style before adding any catalog
         # data raises an error.
         with pytest.raises(
             ValueError,
@@ -299,7 +299,7 @@ class ImageWidgetAPITest:
 
     def test_load_catalog_with_skycoord_no_wcs(self, catalog, data):
         # Check that loading a catalog with skycoord but no x/y and
-        # no WCS returns a catlog with None for x and y.
+        # no WCS returns a catalog with None for x and y.
         self.image.load_array(data)
 
         # Remove x/y columns from the catalog


### PR DESCRIPTION
This implements several things related to catalogs:

1. Change `add_markers`/`get_markers` to `load_catalog`/`get_catalog`.
2. Change `marker_name` to `catalog_label`
3. Add `set_catalog_style`/`get_catalog_style`
4. Made it an error to `set_catalog_style` before the catalog has been loaded. 
5. Made it an error to `get_catalog` or `get_catalog_style` without a `catalog_label` if there is more than one catalog.
6. Test fairly thoroughly for the ability to set/get without using catalog labels if there is only one catalog.
7. Made it an error to `get_catalog` if the provided `catalog_label` is a list.
8. Add and test `get_catalog_names`.

Edit:

- Fixes #28 
- Fixes #29
- Fixes #32 
- Fixes #40 
- Fixes #6