### PR TITLE
Add colormap api

### DIFF
--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -155,7 +155,7 @@ class ImageViewer:
         image_label = self._resolve_image_label(image_label)
         if image_label not in self._images:
             raise ValueError(f"Image label '{image_label}' not found. Please load an image first.")
-        self._images[image_label].colormap = map_name.lower()
+        self._images[image_label].colormap = map_name
 
     set_colormap.__doc__ = ImageViewerInterface.set_colormap.__doc__
 

--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -160,13 +160,13 @@ class ImageViewer:
     colormap_options.__doc__ = ImageViewerInterface.colormap_options.__doc__
 
     def set_colormap(self, map_name: str, image_label: str | None = None) -> None:
-        if map_name not in self.colormap_options:
+        if map_name.lower() not in self.colormap_options:
             raise ValueError(f"Invalid colormap '{map_name}'. Must be one of {self.colormap_options}.")
 
         image_label = self._resolve_image_label(image_label)
         if image_label not in self._images:
             raise ValueError(f"Image label '{image_label}' not found. Please load an image first.")
-        self._images[image_label].colormap = map_name
+        self._images[image_label].colormap = map_name.lower()
 
     set_colormap.__doc__ = ImageViewerInterface.set_colormap.__doc__
 

--- a/src/astro_image_display_api/dummy_viewer.py
+++ b/src/astro_image_display_api/dummy_viewer.py
@@ -59,9 +59,6 @@ class ImageViewer:
     # Allowed locations for cursor display
     ALLOWED_CURSOR_LOCATIONS: tuple = ImageViewerInterface.ALLOWED_CURSOR_LOCATIONS
 
-    # Minimal required colormaps
-    MINIMUM_REQUIRED_COLORMAPS: tuple[str, ...] = ImageViewerInterface.MINIMUM_REQUIRED_COLORMAPS
-
     # some internal variable for keeping track of viewer state
     _wcs: WCS | None = None
     _center: tuple[numbers.Real, numbers.Real] = (0.0, 0.0)
@@ -154,15 +151,7 @@ class ImageViewer:
             raise ValueError(f"Image label '{image_label}' not found. Please load an image first.")
         self._images[image_label].cuts = self._cuts
 
-    @property
-    def colormap_options(self) -> list[str]:
-        return list(self.MINIMUM_REQUIRED_COLORMAPS)
-    colormap_options.__doc__ = ImageViewerInterface.colormap_options.__doc__
-
     def set_colormap(self, map_name: str, image_label: str | None = None) -> None:
-        if map_name.lower() not in self.colormap_options:
-            raise ValueError(f"Invalid colormap '{map_name}'. Must be one of {self.colormap_options}.")
-
         image_label = self._resolve_image_label(image_label)
         if image_label not in self._images:
             raise ValueError(f"Image label '{image_label}' not found. Please load an image first.")

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -12,7 +12,23 @@ from numpy.typing import ArrayLike
 
 # Allowed locations for cursor display
 ALLOWED_CURSOR_LOCATIONS = ('top', 'bottom', None)
-
+MINIMUM_REQUIRED_COLORMAPS = (
+    'gray',
+    'viridis',
+    'plasma',
+    'inferno',
+    'magma',
+    'purple-blue',
+    'yellow-green-blue',
+    'yellow-orange-red',
+    'red-purple',
+    'blue-green',
+    'hot',
+    'red-blue',
+    'red-yellow-blue',
+    'purple-orange'
+    'purple-green',
+)
 
 __all__ = [
     'ImageViewerInterface',
@@ -30,6 +46,9 @@ class ImageViewerInterface(Protocol):
 
     # Allowed locations for cursor display
     ALLOWED_CURSOR_LOCATIONS: tuple = ALLOWED_CURSOR_LOCATIONS
+
+    # Required colormaps for the viewer
+    MINIMUM_REQUIRED_COLORMAPS: tuple[str, ...] = MINIMUM_REQUIRED_COLORMAPS
 
     # The methods, grouped loosely by purpose
 
@@ -127,6 +146,69 @@ class ImageViewerInterface(Protocol):
         -------
         stretch : `~astropy.visualization.BaseStretch`
             The Astropy stretch object representing the current stretch.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_colormap(self, map_name: str, image_label: str | None = None) -> None:
+        """
+        Set the colormap for the image specified by image_label.
+
+        Parameters
+        ----------
+        map_name : str
+            The name of the colormap to set. This should be a valid
+            colormap name from Matplotlib; not all backends will support
+            all colormaps, so the viewer should handle errors gracefully.
+            The case of the `map_name` is not important.
+        image_label : str, optional
+            The label of the image to set the colormap for. If not given and there is
+            only one image loaded, the colormap for that image is set. If there are
+            multiple images and no label is provided, an error is raised.
+
+        Raises
+        ------
+        ValueError
+            If the `map_name` is not a valid colormap name or if the `image_label`
+            is not provided when there are multiple images loaded.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_colormap(self, image_label: str | None = None) -> str:
+        """
+        Get the current colormap for the image.
+
+        Parameters
+        ----------
+        image_label : str, optional
+            The label of the image to get the colormap for. If not given and there is
+            only one image loaded, the colormap for that image is returned. If there are
+            multiple images and no label is provided, an error is raised.
+
+        Returns
+        -------
+        map_name : str
+            The name of the current colormap.
+
+        Raises
+        ------
+        ValueError
+            If the `image_label` is not provided when there are multiple images loaded or if
+            the `image_label` does not correspond to a loaded image.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def colormap_options(self) -> list[str]:
+        """
+        Get the list of available colormaps.
+
+        Returns
+        -------
+        list of str
+            A list of available colormap names.
         """
         raise NotImplementedError
 

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -3,32 +3,13 @@ from abc import abstractmethod
 import os
 
 from astropy.coordinates import SkyCoord
-from astropy.nddata import NDData
 from astropy.table import Table
 from astropy.units import Quantity
 from astropy.visualization import BaseInterval, BaseStretch
 
-from numpy.typing import ArrayLike
 
 # Allowed locations for cursor display
 ALLOWED_CURSOR_LOCATIONS = ('top', 'bottom', None)
-MINIMUM_REQUIRED_COLORMAPS = (
-    'gray',
-    'viridis',
-    'plasma',
-    'inferno',
-    'magma',
-    'purple-blue',
-    'yellow-green-blue',
-    'yellow-orange-red',
-    'red-purple',
-    'blue-green',
-    'hot',
-    'red-blue',
-    'red-yellow-blue',
-    'purple-orange',
-    'purple-green',
-)
 
 __all__ = [
     'ImageViewerInterface',
@@ -46,9 +27,6 @@ class ImageViewerInterface(Protocol):
 
     # Allowed locations for cursor display
     ALLOWED_CURSOR_LOCATIONS: tuple = ALLOWED_CURSOR_LOCATIONS
-
-    # Required colormaps for the viewer
-    MINIMUM_REQUIRED_COLORMAPS: tuple[str, ...] = MINIMUM_REQUIRED_COLORMAPS
 
     # The methods, grouped loosely by purpose
 
@@ -157,10 +135,10 @@ class ImageViewerInterface(Protocol):
         Parameters
         ----------
         map_name : str
-            The name of the colormap to set. This should be a valid
-            colormap name from Matplotlib; not all backends will support
+            The name of the colormap to set. This should be a
+            valid colormap name from Matplotlib`_;
+            not all backends will support
             all colormaps, so the viewer should handle errors gracefully.
-            The case of the `map_name` is not important.
         image_label : str, optional
             The label of the image to set the colormap for. If not given and there is
             only one image loaded, the colormap for that image is set. If there are
@@ -171,6 +149,8 @@ class ImageViewerInterface(Protocol):
         ValueError
             If the `map_name` is not a valid colormap name or if the `image_label`
             is not provided when there are multiple images loaded.
+
+        .. _Matplotlib: https://matplotlib.org/stable/gallery/color/colormap_reference.html
         """
         raise NotImplementedError
 
@@ -196,19 +176,6 @@ class ImageViewerInterface(Protocol):
         ValueError
             If the `image_label` is not provided when there are multiple images loaded or if
             the `image_label` does not correspond to a loaded image.
-        """
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def colormap_options(self) -> list[str]:
-        """
-        Get the list of available colormaps.
-
-        Returns
-        -------
-        list of str
-            A list of available colormap names.
         """
         raise NotImplementedError
 

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -26,7 +26,7 @@ MINIMUM_REQUIRED_COLORMAPS = (
     'hot',
     'red-blue',
     'red-yellow-blue',
-    'purple-orange'
+    'purple-orange',
     'purple-green',
 )
 

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -735,6 +735,19 @@ class ImageWidgetAPITest:
         self.image.set_colormap(new_cmap, image_label='test')
         assert self.image.get_colormap(image_label='test') == new_cmap
 
+    def test_set_get_colormap_map_name_case_insensitive(self, data):
+        # Check that the colormap can be set with a name that is not
+        # case-sensitive.
+        self.image.load_image(data, image_label='test')
+        cmap_desired = 'GrAy'
+        self.image.set_colormap(cmap_desired)
+        assert self.image.get_colormap() == cmap_desired.lower()
+
+        # Set the colormap with a different case
+        new_cmap = "Viridis"
+        self.image.set_colormap(new_cmap, image_label='test')
+        assert self.image.get_colormap(image_label='test') == 'viridis'
+
     def test_set_colormap_errors(self, data):
         # Check that setting a colormap raises an error if the colormap
         # is not in the list of allowed colormaps.

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -718,11 +718,6 @@ class ImageWidgetAPITest:
         with pytest.raises(ValueError, match='[Ii]mage label.*not found'):
             self.image.set_cuts((10, 100), image_label='not a valid label')
 
-    def test_colormap_options(self):
-        cmap_list = self.image.colormap_options
-        assert set(ImageViewerInterface.MINIMUM_REQUIRED_COLORMAPS) <= set(cmap_list)
-        assert set(self.image.MINIMUM_REQUIRED_COLORMAPS) == set(ImageViewerInterface.MINIMUM_REQUIRED_COLORMAPS)
-
     def test_set_get_colormap(self, data):
         # Check setting and getting with a single image label.
         self.image.load_image(data, image_label='test')
@@ -752,9 +747,6 @@ class ImageWidgetAPITest:
         # Check that setting a colormap raises an error if the colormap
         # is not in the list of allowed colormaps.
         self.image.load_image(data, image_label='test')
-
-        with pytest.raises(ValueError, match='[Ii]nvalid colormap'):
-            self.image.set_colormap('not a valid colormap')
 
         # Check that getting a colormap for an image label that does not exist
         with pytest.raises(ValueError, match='[Ii]mage label.*not found'):

--- a/src/astro_image_display_api/widget_api_test.py
+++ b/src/astro_image_display_api/widget_api_test.py
@@ -730,19 +730,6 @@ class ImageWidgetAPITest:
         self.image.set_colormap(new_cmap, image_label='test')
         assert self.image.get_colormap(image_label='test') == new_cmap
 
-    def test_set_get_colormap_map_name_case_insensitive(self, data):
-        # Check that the colormap can be set with a name that is not
-        # case-sensitive.
-        self.image.load_image(data, image_label='test')
-        cmap_desired = 'GrAy'
-        self.image.set_colormap(cmap_desired)
-        assert self.image.get_colormap() == cmap_desired.lower()
-
-        # Set the colormap with a different case
-        new_cmap = "Viridis"
-        self.image.set_colormap(new_cmap, image_label='test')
-        assert self.image.get_colormap(image_label='test') == 'viridis'
-
     def test_set_colormap_errors(self, data):
         # Check that setting a colormap raises an error if the colormap
         # is not in the list of allowed colormaps.


### PR DESCRIPTION
This pull request implements a colormap API. This wasn't discussed in the API meeting at STScI, but follows the pattern of the other APIs, like that for stretch and cuts.

I made some somewhat arbitrary decisions here:

1. The minimal set of colormaps that must be supported is those currently support in glue, but with....
2. ...the proper lowercase names they ought to have.
3. Added a statement in the API that colormap names in set_colormap should be case insensitive.
4. Added a test that really requires that colormap names be lower case. 
5. I put in a `colormap_options` property.

Fixes #47 
Fixes #48 

ping @kecnry @bmorris3 @ejeschke for awareness..