### PR TITLE
Add test for and fix bug in viewer logic

### DIFF
--- a/src/astro_image_display_api/api_test.py
+++ b/src/astro_image_display_api/api_test.py
@@ -438,6 +438,21 @@ class ImageAPITest:
         del retrieved_style["catalog_label"]  # Remove the label
         assert retrieved_style == style
 
+    def test_catalog_has_style_after_loading(self, catalog):
+        # Check that loading a catalog sets a default style for that catalog.
+        self.image.load_catalog(catalog, catalog_label="test1")
+
+        retrieved_style = self.image.get_catalog_style(catalog_label="test1")
+        assert isinstance(retrieved_style, dict)
+        assert "color" in retrieved_style
+        assert "shape" in retrieved_style
+        assert "size" in retrieved_style
+
+        # Loading again should have the same style
+        self.image.load_catalog(catalog, catalog_label="test1")
+        retrieved_style2 = self.image.get_catalog_style(catalog_label="test1")
+        assert retrieved_style2 == retrieved_style
+
     @pytest.mark.parametrize("catalog_label", ["test1", None])
     def test_load_get_single_catalog_with_without_label(self, catalog, catalog_label):
         # Make sure we can get a single catalog with or without a label.

--- a/src/astro_image_display_api/image_viewer_logic.py
+++ b/src/astro_image_display_api/image_viewer_logic.py
@@ -26,6 +26,7 @@ from .interface_definition import ImageViewerInterface
 
 __all__ = ["ImageViewerLogic"]
 
+
 @dataclass
 class CatalogInfo:
     """
@@ -523,7 +524,11 @@ class ImageViewerLogic:
         # Ensure a catalog always has a style
         if catalog_style is None:
             if not self._catalogs[catalog_label].style:
+                # No style has been set, so use the default style
                 catalog_style = self._default_catalog_style.copy()
+            else:
+                # Use the existing style
+                catalog_style = self._catalogs[catalog_label].style.copy()
 
         self._catalogs[catalog_label].style = catalog_style
 


### PR DESCRIPTION
The bug was that the second time loda_cagatalog is called without a style argument the style gets set to None instead of the default style.