### PR TITLE
Change get methods to properties

### DIFF
--- a/src/astro_image_display_api/api_test.py
+++ b/src/astro_image_display_api/api_test.py
@@ -522,7 +522,7 @@ class ImageAPITest:
         # other one without a label.
         self.image.remove_catalog(catalog_label="test1")
         # Make sure test1 is really gone.
-        assert self.image.catalog_names == ["test2"]
+        assert self.image.catalog_names == ("test2",)
 
         # Get without a catalog
         t2 = self.image.get_catalog()
@@ -800,12 +800,11 @@ class ImageAPITest:
 
     def test_image_labels(self, data):
         # the test viewer begins with a default empty image
-        assert len(self.image.image_labels) == 1
-        assert self.image.image_labels[0] is None
+        assert len(self.image.image_labels) == 0
         assert isinstance(self.image.image_labels, tuple)
 
         self.image.load_image(data, image_label="test")
-        assert len(self.image.image_labels) == 2
+        assert len(self.image.image_labels) == 1
         assert self.image.image_labels[-1] == "test"
 
     def test_get_image(self, data):

--- a/src/astro_image_display_api/api_test.py
+++ b/src/astro_image_display_api/api_test.py
@@ -78,7 +78,7 @@ class ImageAPITest:
         assert sorted(table.colnames) == sorted(["x", "y", "coord"])
 
     def _get_catalog_names_as_set(self):
-        marks = self.image.get_catalog_names()
+        marks = self.image.catalog_names
         return set(marks)
 
     def test_width_height(self):
@@ -498,7 +498,7 @@ class ImageAPITest:
             catalog_label="test2",
         )
 
-        assert sorted(self.image.get_catalog_names()) == ["test1", "test2"]
+        assert sorted(self.image.catalog_names) == ["test1", "test2"]
 
         # No guarantee markers will come back in the same order, so sort them.
         t1 = self.image.get_catalog(catalog_label="test1")
@@ -522,7 +522,7 @@ class ImageAPITest:
         # other one without a label.
         self.image.remove_catalog(catalog_label="test1")
         # Make sure test1 is really gone.
-        assert self.image.get_catalog_names() == ["test2"]
+        assert self.image.catalog_names == ["test2"]
 
         # Get without a catalog
         t2 = self.image.get_catalog()
@@ -798,15 +798,15 @@ class ImageAPITest:
         # Using overwrite should save successfully
         self.image.save(filename, overwrite=True)
 
-    def test_get_image_labels(self, data):
+    def test_image_labels(self, data):
         # the test viewer begins with a default empty image
-        assert len(self.image.get_image_labels()) == 1
-        assert self.image.get_image_labels()[0] is None
-        assert isinstance(self.image.get_image_labels(), tuple)
+        assert len(self.image.image_labels) == 1
+        assert self.image.image_labels[0] is None
+        assert isinstance(self.image.image_labels, tuple)
 
         self.image.load_image(data, image_label="test")
-        assert len(self.image.get_image_labels()) == 2
-        assert self.image.get_image_labels()[-1] == "test"
+        assert len(self.image.image_labels) == 2
+        assert self.image.image_labels[-1] == "test"
 
     def test_get_image(self, data):
         self.image.load_image(data, image_label="test")

--- a/src/astro_image_display_api/image_viewer_logic.py
+++ b/src/astro_image_display_api/image_viewer_logic.py
@@ -373,7 +373,7 @@ class ImageViewerLogic:
 
     @property
     def image_labels(self) -> tuple[str, ...]:
-        return tuple(self._images.keys())
+        return tuple(k for k in self._images.keys() if k is not None)
 
     image_labels.__doc__ = ImageViewerInterface.image_labels.__doc__
 
@@ -649,7 +649,7 @@ class ImageViewerLogic:
 
     @property
     def catalog_names(self) -> tuple[str, ...]:
-        return list(self._user_catalog_labels())
+        return tuple(self._user_catalog_labels())
 
     catalog_names.__doc__ = ImageViewerInterface.catalog_names.__doc__
 

--- a/src/astro_image_display_api/image_viewer_logic.py
+++ b/src/astro_image_display_api/image_viewer_logic.py
@@ -371,11 +371,11 @@ class ImageViewerLogic:
             )
         return self._images[image_label].data
 
-    def get_image_labels(
-        self,
-        **kwargs,  # noqa: ARG002
-    ) -> tuple[str, ...]:
+    @property
+    def image_labels(self) -> tuple[str, ...]:
         return tuple(self._images.keys())
+
+    image_labels.__doc__ = ImageViewerInterface.image_labels.__doc__
 
     def _determine_largest_dimension(self, shape: tuple[int, int]) -> int:
         """
@@ -647,13 +647,11 @@ class ImageViewerLogic:
 
     get_catalog.__doc__ = ImageViewerInterface.get_catalog.__doc__
 
-    def get_catalog_names(
-        self,
-        **kwargs,  # noqa: ARG002
-    ) -> list[str]:
+    @property
+    def catalog_names(self) -> tuple[str, ...]:
         return list(self._user_catalog_labels())
 
-    get_catalog_names.__doc__ = ImageViewerInterface.get_catalog_names.__doc__
+    catalog_names.__doc__ = ImageViewerInterface.catalog_names.__doc__
 
     # Methods that modify the view
     def set_viewport(

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -555,7 +555,7 @@ class ImageViewerInterface(Protocol):
 
         Returns
         -------
-        list of str
+        tuple of str
             The names of the loaded catalogs.
 
         Notes

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -85,13 +85,13 @@ class ImageViewerInterface(Protocol):
         """
         raise NotImplementedError
 
+    @property
     @abstractmethod
-    def get_image_labels(
+    def image_labels(
         self,
-        **kwargs,
-    ) -> tuple[str]:
+    ) -> tuple[str, ...]:
         """
-        Get the labels of the loaded images.
+        Labels of the loaded images.
 
         Returns
         -------
@@ -547,10 +547,11 @@ class ImageViewerInterface(Protocol):
         """
         raise NotImplementedError
 
+    @property
     @abstractmethod
-    def get_catalog_names(self) -> list[str]:
+    def catalog_names(self) -> tuple[str, ...]:
         """
-        Get the names of the loaded catalogs.
+        Names of the loaded catalogs.
 
         Returns
         -------


### PR DESCRIPTION
There are a couple of get methods, `get_image_labels` and `get_catalog_names`, that make sense as properties because they take no paramaters. In both cases the methods are changed to properties, and only *user-provided* labels and names are returned, i.e. `None` is never returned as a name or label.