### PR TITLE
Remove `image_height` and `image_width` attributes; test that every method/attribute has docs

### DIFF
--- a/src/astro_image_display_api/api_test.py
+++ b/src/astro_image_display_api/api_test.py
@@ -906,3 +906,25 @@ class ImageAPITest:
             "The following methods failed when called with additional kwargs:\n\t"
             f"{'\n\t'.join(failed_methods)}"
         )
+
+    def test_every_method_attribute_has_docstring(self):
+        """
+        Check that every method and attribute in the protocol has a docstring.
+        """
+        from astro_image_display_api import ImageViewerInterface
+
+        all_methods_and_attributes = ImageViewerInterface.__protocol_attrs__
+
+        method_attrs_no_docs = []
+
+        for method in all_methods_and_attributes:
+            attr = getattr(self.image, method)
+            # Make list of methods and attributes that have no docstring
+            # and assert that list is empty at the end of the test.
+            if not attr.__doc__:
+                method_attrs_no_docs.append(method)
+
+        assert not method_attrs_no_docs, (
+            "The following methods and attributes have no docstring:\n\t"
+            f"{'\n\t'.join(method_attrs_no_docs)}"
+        )

--- a/src/astro_image_display_api/api_test.py
+++ b/src/astro_image_display_api/api_test.py
@@ -18,12 +18,14 @@ from astropy.wcs import WCS
 
 __all__ = ["ImageAPITest"]
 
+DEFAULT_IMAGE_SHAPE = (100, 150)
+
 
 class ImageAPITest:
     @pytest.fixture
     def data(self):
         rng = np.random.default_rng(1234)
-        return rng.random((100, 150))
+        return rng.random(DEFAULT_IMAGE_SHAPE)
 
     @pytest.fixture
     def wcs(self):
@@ -49,8 +51,8 @@ class ImageAPITest:
         expected columns.
         """
         rng = np.random.default_rng(45328975)
-        x = rng.uniform(0, self.image.image_width, size=10)
-        y = rng.uniform(0, self.image.image_height, size=10)
+        x = rng.uniform(0, DEFAULT_IMAGE_SHAPE[0], size=10)
+        y = rng.uniform(0, DEFAULT_IMAGE_SHAPE[1], size=10)
         coord = wcs.pixel_to_world(x, y)
 
         cat = Table(
@@ -70,7 +72,7 @@ class ImageAPITest:
         Subclasses MUST define ``image_widget_class`` -- doing so as a
         class variable does the trick.
         """
-        self.image = self.image_widget_class(image_width=250, image_height=100)
+        self.image = self.image_widget_class()
 
     def _assert_empty_catalog_table(self, table):
         assert isinstance(table, Table)
@@ -80,17 +82,6 @@ class ImageAPITest:
     def _get_catalog_names_as_set(self):
         marks = self.image.catalog_names
         return set(marks)
-
-    def test_width_height(self):
-        assert self.image.image_width == 250
-        assert self.image.image_height == 100
-
-        width = 200
-        height = 300
-        self.image.image_width = width
-        self.image.image_height = height
-        assert self.image.image_width == width
-        assert self.image.image_height == height
 
     @pytest.mark.parametrize("load_type", ["fits", "nddata", "array"])
     def test_load(self, data, tmp_path, load_type):

--- a/src/astro_image_display_api/image_viewer_logic.py
+++ b/src/astro_image_display_api/image_viewer_logic.py
@@ -135,6 +135,8 @@ class ImageViewerLogic:
             )
         return self._images[image_label].stretch
 
+    get_stretch.__doc__ = ImageViewerInterface.get_stretch.__doc__
+
     def set_stretch(
         self,
         value: BaseStretch,
@@ -153,6 +155,8 @@ class ImageViewerLogic:
             )
         self._images[image_label].stretch = value
 
+    set_stretch.__doc__ = ImageViewerInterface.set_stretch.__doc__
+
     def get_cuts(
         self,
         image_label: str | None = None,
@@ -164,6 +168,8 @@ class ImageViewerLogic:
                 f"Image label '{image_label}' not found. Please load an image first."
             )
         return self._images[image_label].cuts
+
+    get_cuts.__doc__ = ImageViewerInterface.get_cuts.__doc__
 
     def set_cuts(
         self,
@@ -186,6 +192,8 @@ class ImageViewerLogic:
                 f"Image label '{image_label}' not found. Please load an image first."
             )
         self._images[image_label].cuts = self._cuts
+
+    set_cuts.__doc__ = ImageViewerInterface.set_cuts.__doc__
 
     def set_colormap(
         self,
@@ -364,6 +372,8 @@ class ImageViewerLogic:
                 f"Image label '{image_label}' not found. Please load an image first."
             )
         return self._images[image_label].data
+
+    get_image.__doc__ = ImageViewerInterface.get_image.__doc__
 
     @property
     def image_labels(self) -> tuple[str, ...]:

--- a/src/astro_image_display_api/image_viewer_logic.py
+++ b/src/astro_image_display_api/image_viewer_logic.py
@@ -60,12 +60,6 @@ class ImageViewerLogic:
     state to simulate the behavior of a real viewer.
     """
 
-    # These are attributes, not methods. The type annotations are there
-    # to make sure Protocol knows they are attributes. Python does not
-    # do any checking at all of these types.
-    image_width: int = 0
-    image_height: int = 0
-    zoom_level: float = 1
     _cuts: BaseInterval | tuple[float, float] = AsymmetricPercentileInterval(
         upper_percentile=95
     )

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -15,12 +15,6 @@ __all__ = [
 
 @runtime_checkable
 class ImageViewerInterface(Protocol):
-    # These are attributes, not methods. The type annotations are there
-    # to make sure Protocol knows they are attributes. Python does not
-    # do any checking at all of these types.
-    image_width: int
-    image_height: int
-
     # The methods, grouped loosely by purpose
 
     # Method for loading image data

--- a/tests/test_astro_image_display_api.py
+++ b/tests/test_astro_image_display_api.py
@@ -72,3 +72,26 @@ def test_api_test_class_covers_all_attributes_and_only_those_attributes():
         "ImageWidgetAPITest does not access these "
         f"attributes/methods:\n{missing_attributes_msg}\n"
     )
+
+
+def test_every_method_attribute_has_docstring():
+    """
+    Check that every method and attribute in the protocol has a docstring.
+    """
+    from astro_image_display_api import ImageViewerInterface
+
+    all_methods_and_attributes = ImageViewerInterface.__protocol_attrs__
+
+    method_attrs_no_docs = []
+
+    for method in all_methods_and_attributes:
+        attr = getattr(ImageViewerInterface, method)
+        # Make list of methods and attributes that have no docstring
+        # and assert that list is empty at the end of the test.
+        if not attr.__doc__:
+            method_attrs_no_docs.append(method)
+
+    assert not method_attrs_no_docs, (
+        "The following methods and attributes have no docstring:\n\t"
+        f"{'\n\t'.join(method_attrs_no_docs)}"
+    )


### PR DESCRIPTION
This removes the `image_height` and `image_width` properties. These things are determined by the image that is loaded.

This also checks that every method/property in the interface and the sample implementation has a docstring.