### PR TITLE
Minor api cleanup

### DIFF
--- a/src/astro_image_display_api/api_test.py
+++ b/src/astro_image_display_api/api_test.py
@@ -534,7 +534,7 @@ class ImageAPITest:
         self.image.load_catalog(catalog, catalog_label="test1")
 
         retrieved_catalog = self.image.get_catalog(catalog_label="test1")
-        assert len(retrieved_catalog) == 2 * len(catalog)
+        assert len(retrieved_catalog) == len(catalog)
 
     def test_load_catalog_with_skycoord_no_wcs(self, catalog, data):
         # Check that loading a catalog with skycoord but no x/y and

--- a/src/astro_image_display_api/api_test.py
+++ b/src/astro_image_display_api/api_test.py
@@ -362,7 +362,7 @@ class ImageAPITest:
         with pytest.raises(
             ValueError, match="Must load a catalog before setting a catalog style"
         ):
-            self.image.set_catalog_style(color="red", shape="x", size=10)
+            self.image.set_catalog_style(color="red", shape="circle", size=10)
 
     def test_set_get_catalog_style_no_labels(self, catalog):
         # Check that getting without setting returns a dict that contains
@@ -376,7 +376,7 @@ class ImageAPITest:
         # Add some data before setting a style
         self.image.load_catalog(catalog)
         # Check that setting a marker style works
-        marker_settings = dict(color="red", shape="x", size=10)
+        marker_settings = dict(color="red", shape="crosshair", size=10)
         self.image.set_catalog_style(**marker_settings.copy())
 
         retrieved_style = self.image.get_catalog_style()
@@ -421,7 +421,7 @@ class ImageAPITest:
         # The only required keywords are color, shape, and size.
         # Add some extra keyword to the style.
         style = dict(
-            color="blue", shape="x", size=10, extra_kw="extra_value", alpha=0.5
+            color="blue", shape="circle", size=10, extra_kw="extra_value", alpha=0.5
         )
         self.image.set_catalog_style(**style.copy())
 
@@ -605,7 +605,7 @@ class ImageAPITest:
     def test_load_catalog_with_style_sets_style(self, catalog):
         # Check that loading a catalog with a style sets the style
         # for that catalog.
-        style = dict(color="blue", shape="x", size=10)
+        style = dict(color="blue", shape="square", size=10)
         self.image.load_catalog(
             catalog, catalog_label="test1", catalog_style=style.copy()
         )

--- a/src/astro_image_display_api/api_test.py
+++ b/src/astro_image_display_api/api_test.py
@@ -79,8 +79,8 @@ class ImageAPITest:
         assert len(table) == 0
         assert sorted(table.colnames) == sorted(["x", "y", "coord"])
 
-    def _get_catalog_names_as_set(self):
-        marks = self.image.catalog_names
+    def _get_catalog_labels_as_set(self):
+        marks = self.image.catalog_labels
         return set(marks)
 
     @pytest.mark.parametrize("load_type", ["fits", "nddata", "array"])
@@ -489,7 +489,7 @@ class ImageAPITest:
             catalog_label="test2",
         )
 
-        assert sorted(self.image.catalog_names) == ["test1", "test2"]
+        assert sorted(self.image.catalog_labels) == ["test1", "test2"]
 
         # No guarantee markers will come back in the same order, so sort them.
         t1 = self.image.get_catalog(catalog_label="test1")
@@ -513,7 +513,7 @@ class ImageAPITest:
         # other one without a label.
         self.image.remove_catalog(catalog_label="test1")
         # Make sure test1 is really gone.
-        assert self.image.catalog_names == ("test2",)
+        assert self.image.catalog_labels == ("test2",)
 
         # Get without a catalog
         t2 = self.image.get_catalog()

--- a/src/astro_image_display_api/api_test.py
+++ b/src/astro_image_display_api/api_test.py
@@ -543,13 +543,10 @@ class ImageAPITest:
 
         # Remove x/y columns from the catalog
         del catalog["x", "y"]
-        self.image.load_catalog(catalog)
-        # Retrieve the catalog and check that the x and y columns are None
-        retrieved_catalog = self.image.get_catalog()
-        assert "x" in retrieved_catalog.colnames
-        assert "y" in retrieved_catalog.colnames
-        assert all(rc is None for rc in retrieved_catalog["x"])
-        assert all(rc is None for rc in retrieved_catalog["y"])
+        with pytest.raises(
+            ValueError, match="Cannot use pixel coordinates without pixel columns"
+        ):
+            self.image.load_catalog(catalog)
 
     def test_load_catalog_with_use_skycoord_no_skycoord_no_wcs(self, catalog, data):
         # Check that loading a catalog with use_skycoord=True but no

--- a/src/astro_image_display_api/image_viewer_logic.py
+++ b/src/astro_image_display_api/image_viewer_logic.py
@@ -492,8 +492,15 @@ class ImageViewerLogic:
                 x, y = self._wcs.world_to_pixel(coords)
                 to_add[x_colname] = x
                 to_add[y_colname] = y
+                xy = (x, y)
             else:
                 to_add[x_colname] = to_add[y_colname] = None
+
+        if not use_skycoord and xy is None:
+            raise ValueError(
+                "Cannot use pixel coordinates without pixel columns or both "
+                "coordinates and a WCS."
+            )
 
         if coords is None:
             if use_skycoord and self._wcs is None:
@@ -703,13 +710,15 @@ class ImageViewerLogic:
                         "sky coordinates."
                     )
                 else:
-                    center = viewport.wcs.pixel_to_world(
-                        viewport.center[0], viewport.center[1]
-                    )
-                    pixel_scale = proj_plane_pixel_scales(viewport.wcs)[
-                        viewport.largest_dimension
-                    ]
-                    fov = pixel_scale * viewport.fov * u.degree
+                    if center is None:
+                        center = viewport.wcs.pixel_to_world(
+                            viewport.center[0], viewport.center[1]
+                        )
+                    if fov is None:
+                        pixel_scale = proj_plane_pixel_scales(viewport.wcs)[
+                            viewport.largest_dimension
+                        ]
+                        fov = pixel_scale * viewport.fov * u.degree
         else:
             # Pixel coordinates
             if isinstance(viewport.center, SkyCoord):

--- a/src/astro_image_display_api/image_viewer_logic.py
+++ b/src/astro_image_display_api/image_viewer_logic.py
@@ -9,7 +9,7 @@ from typing import Any
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.nddata import CCDData, NDData
-from astropy.table import Table, vstack
+from astropy.table import Table
 from astropy.units import Quantity
 from astropy.visualization import (
     AsymmetricPercentileInterval,
@@ -509,17 +509,8 @@ class ImageViewerLogic:
 
         catalog_label = self._resolve_catalog_label(catalog_label)
 
-        # Either set new data or append to existing data
-        if (
-            catalog_label in self._catalogs
-            and self._catalogs[catalog_label].data is not None
-        ):
-            # If the catalog already exists, we append to it
-            old_table = self._catalogs[catalog_label].data
-            self._catalogs[catalog_label].data = vstack([old_table, to_add])
-        else:
-            # If the catalog does not exist, we create a new one
-            self._catalogs[catalog_label].data = to_add
+        # Set the new data
+        self._catalogs[catalog_label].data = to_add
 
         # Ensure a catalog always has a style
         if catalog_style is None:

--- a/src/astro_image_display_api/image_viewer_logic.py
+++ b/src/astro_image_display_api/image_viewer_logic.py
@@ -590,7 +590,7 @@ class ImageViewerLogic:
         return result
 
     @property
-    def catalog_names(self) -> tuple[str, ...]:
+    def catalog_labels(self) -> tuple[str, ...]:
         return tuple(self._user_catalog_labels())
 
     # Methods that modify the view

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -543,7 +543,7 @@ class ImageViewerInterface(Protocol):
 
     @property
     @abstractmethod
-    def catalog_names(self) -> tuple[str, ...]:
+    def catalog_labels(self) -> tuple[str, ...]:
         """
         Names of the loaded catalogs.
 

--- a/src/astro_image_display_api/interface_definition.py
+++ b/src/astro_image_display_api/interface_definition.py
@@ -345,6 +345,9 @@ class ImageViewerInterface(Protocol):
         """
         Add catalog entries to the viewer at positions given by the catalog.
 
+        Loading a catalog using a ``catalog_label`` that already exists will
+        overwrite the existing catalog with the new one.
+
         Parameters
         ----------
         table : `astropy.table.Table`


### PR DESCRIPTION
Turns out there were a few things that needed to be addressed:

- Several catalog style tests used shape names that are not part of the API.
- One test deliberately loaded a catalog without x/y columns, indicated that the x/y columns should be used (as opposed to sky coord), for an image with no wcs, and did not expect the code to raise an error. That is...silly.
