### PR TITLE
Add test of viewport initialization and fix error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,7 +184,11 @@ man_pages = [("index", project.lower(), project + " Documentation", [author], 1)
 # -- Turn on nitpicky mode for sphinx (to warn about references not found) ----
 #
 nitpicky = True
-nitpick_ignore = []
+nitpick_ignore = [
+    # numpy.typing.ArrayLike resolves to a private path that numpy's
+    # intersphinx inventory does not expose, so it can never be cross-referenced.
+    ("py:class", "numpy._typing._array_like.ArrayLike"),
+]
 #
 # Some warnings are impossible to suppress, and you can list specific references
 # that should be ignored in a nitpick-exceptions file which should be inside

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ docs = [
     "sphinx-astropy[confv2]",
     "sphinx-design",
     "graphviz",
+    "pytest",
 ]
 test = [
     "black",

--- a/src/astro_image_display_api/__init__.py
+++ b/src/astro_image_display_api/__init__.py
@@ -7,5 +7,4 @@ try:
 except ImportError:
     __version__ = ""
 
-from .api_test import *  # noqa: F403
 from .interface_definition import *  # noqa: F403

--- a/src/astro_image_display_api/api_test.py
+++ b/src/astro_image_display_api/api_test.py
@@ -117,6 +117,27 @@ class ImageAPITest:
         assert vport["center"].ra.deg == pytest.approx(wcs.wcs.crval[0])
         assert vport["center"].dec.deg == pytest.approx(wcs.wcs.crval[1])
 
+    @pytest.mark.parametrize("world", [True, False])
+    def test_fov_initialization_from_image(self, data, wcs, world):
+        # Check that the FOV is initialized to a reasonable value when an image
+        # is loaded.
+        self.image.load_image(
+            NDData(
+                data=data,
+                wcs=wcs if world else None,
+            ),
+            image_label="test"
+        )
+        vport = self.image.get_viewport(image_label="test")
+        if world:
+            assert isinstance(vport["fov"], u.Quantity)
+            assert vport["fov"].unit.physical_type == "angle"
+            pixel_scale = np.mean(np.abs(wcs.wcs.cdelt))
+            assert vport["fov"].value == pytest.approx(max(data.shape) * pixel_scale)
+        else:
+            assert isinstance(vport["fov"], numbers.Real)
+            assert vport["fov"] == pytest.approx(max(data.shape))
+
     def test_set_get_fov_pixel(self, data):
         # Set data first, since that is needed to determine zoom level
         self.image.load_image(data, image_label="test")

--- a/src/astro_image_display_api/image_viewer_logic.py
+++ b/src/astro_image_display_api/image_viewer_logic.py
@@ -391,7 +391,7 @@ class ImageViewerLogic:
             fov = (
                 fov
                 * u.degree
-                / proj_plane_pixel_scales(wcs)[
+                * proj_plane_pixel_scales(wcs)[
                     self._images[image_label].largest_dimension
                 ]
             )

--- a/tests/test_image_viewer_logic.py
+++ b/tests/test_image_viewer_logic.py
@@ -1,6 +1,7 @@
 # All implementations of the ImageViewerInterface will need to import
 # these to carry out the tests.
-from astro_image_display_api import ImageViewerInterface, ImageAPITest  # noqa: I001
+from astro_image_display_api import ImageViewerInterface  # noqa: I001
+from astro_image_display_api.api_test import ImageAPITest
 
 # This import should be replaced with an import of your specific
 # implementation of the ImageViewerInterface. If you keep the


### PR DESCRIPTION
The initial viewport size was being set incorrectly in the sample implementation included in this repository. This pull request adds a test for the issue to api_test and fixes the issue.