### PR TITLE
Fix get_catalog defects; use per-image WCS for catalog conversions and get_viewport

### DIFF
--- a/src/astro_image_display_api/api_test.py
+++ b/src/astro_image_display_api/api_test.py
@@ -778,6 +778,78 @@ class ImageAPITest:
         coords = wcs.pixel_to_world(catalog["x"], catalog["y"])
         assert all(coords.separation(retrieved_catalog["coord"]) < 1e-9 * u.deg)
 
+    def test_get_catalog_empty_on_fresh_viewer(self):
+        # Regression test for #90: get_catalog on a viewer with no catalog
+        # loaded must return an empty table with the requested column
+        # names rather than raising.
+        self._assert_empty_catalog_table(self.image.get_catalog())
+
+        tab = self.image.get_catalog(
+            x_colname="px", y_colname="py", skycoord_colname="sky"
+        )
+        assert len(tab) == 0
+        assert sorted(tab.colnames) == sorted(["px", "py", "sky"])
+
+    def test_load_get_catalog_custom_column_names(self, catalog):
+        # Regression test for #90: a catalog loaded with non-default column
+        # names must be retrievable with those names...
+        renamed = catalog.copy()
+        renamed.rename_columns(["x", "y", "coord"], ["px", "py", "sky"])
+        self.image.load_catalog(
+            renamed,
+            x_colname="px",
+            y_colname="py",
+            skycoord_colname="sky",
+            catalog_label="cat",
+        )
+
+        tab = self.image.get_catalog(
+            x_colname="px", y_colname="py", skycoord_colname="sky", catalog_label="cat"
+        )
+        assert sorted(tab.colnames) == sorted(["px", "py", "sky"])
+        np.testing.assert_allclose(tab["px"], catalog["x"])
+        np.testing.assert_allclose(tab["py"], catalog["y"])
+
+        # ...and get_catalog must return whatever column names are asked for.
+        tab = self.image.get_catalog(catalog_label="cat")
+        assert sorted(tab.colnames) == sorted(["x", "y", "coord"])
+        np.testing.assert_allclose(tab["x"], catalog["x"])
+
+    def test_get_catalog_renames_columns(self, catalog):
+        # Regression test for #90: renaming the position columns to the
+        # requested names must actually happen instead of being a silent
+        # no-op that returns the default names.
+        self.image.load_catalog(catalog, catalog_label="cat")
+
+        tab = self.image.get_catalog(
+            x_colname="xcen",
+            y_colname="ycen",
+            skycoord_colname="sky",
+            catalog_label="cat",
+        )
+        assert "xcen" in tab.colnames
+        assert "ycen" in tab.colnames
+        assert "sky" in tab.colnames
+        assert "x" not in tab.colnames
+        assert "y" not in tab.colnames
+        assert "coord" not in tab.colnames
+        np.testing.assert_allclose(tab["xcen"], catalog["x"])
+        np.testing.assert_allclose(tab["ycen"], catalog["y"])
+
+    def test_get_catalog_returns_copy(self, catalog):
+        # Regression test for #90: the returned table must be a copy, so
+        # that modifying it cannot corrupt the stored catalog.
+        self.image.load_catalog(catalog, catalog_label="cat")
+
+        tab = self.image.get_catalog(catalog_label="cat")
+        original_value = tab["x"][0]
+        tab["x"][0] = -999.0
+        tab.remove_column("y")
+
+        again = self.image.get_catalog(catalog_label="cat")
+        assert again["x"][0] == original_value
+        assert "y" in again.colnames
+
     def test_catalog_info_preserved_after_load(self, catalog):
         # Make sure that any catalog columns in addition to the position data
         # is preserved after loading a catalog.
@@ -881,6 +953,86 @@ class ImageAPITest:
         np.testing.assert_allclose(
             result["coord"].dec.deg, mark_coord_table["coord"].dec.deg
         )
+
+    @staticmethod
+    def _make_tan_wcs(crval, crpix, scale=0.001):
+        wcs = WCS(naxis=2)
+        wcs.wcs.crpix = list(crpix)
+        wcs.wcs.cdelt = [-scale, scale]
+        wcs.wcs.crval = list(crval)
+        wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+        return wcs
+
+    def test_catalog_conversion_uses_single_image_wcs(self, data):
+        # Regression test for #91: catalog pixel<->sky conversion must use
+        # the WCS of the one loaded image, and later image loads must not
+        # rewrite a previously loaded catalog's coordinates.
+        wcs1 = self._make_tan_wcs(crval=(150.0, 30.0), crpix=(50.0, 50.0))
+        wcs2 = self._make_tan_wcs(crval=(10.0, -45.0), crpix=(500.0, 500.0))
+
+        self.image.load_image(NDData(data=data, wcs=wcs1), image_label="a")
+
+        coord = wcs1.pixel_to_world([10.0, 20.0], [30.0, 40.0])
+        self.image.load_catalog(Table(dict(coord=coord)), catalog_label="cat")
+
+        # Loading a second image with a different WCS must not change the
+        # already-computed pixel positions of the catalog.
+        self.image.load_image(NDData(data=data, wcs=wcs2), image_label="b")
+
+        tab = self.image.get_catalog(catalog_label="cat")
+        np.testing.assert_allclose(tab["x"], [10.0, 20.0], atol=1e-6)
+        np.testing.assert_allclose(tab["y"], [30.0, 40.0], atol=1e-6)
+
+    def test_load_catalog_ambiguous_wcs_raises(self, data):
+        # Regression test for #91: with several images loaded there is no
+        # way to know which image's WCS to use to convert the catalog's
+        # sky coordinates to pixels, so loading must raise instead of
+        # silently using the last-loaded image's WCS.
+        wcs1 = self._make_tan_wcs(crval=(150.0, 30.0), crpix=(50.0, 50.0))
+        wcs2 = self._make_tan_wcs(crval=(150.0, 30.0), crpix=(500.0, 500.0))
+        self.image.load_image(NDData(data=data, wcs=wcs1), image_label="a")
+        self.image.load_image(NDData(data=data, wcs=wcs2), image_label="b")
+
+        coord = SkyCoord([150.0], [30.0], unit="deg")
+        with pytest.raises(ValueError, match="Multiple image labels"):
+            self.image.load_catalog(Table(dict(coord=coord)), catalog_label="cat")
+
+        # Requesting sky coordinates from a pixel-only catalog is just as
+        # ambiguous.
+        pixel_only = Table(dict(x=[1.0], y=[2.0]))
+        with pytest.raises(ValueError, match="Multiple image labels"):
+            self.image.load_catalog(pixel_only, use_skycoord=True, catalog_label="cat")
+
+    def test_load_catalog_pixel_only_with_multiple_images(self, data):
+        # Regression test for #91: a pixel-only catalog needs no WCS, so it
+        # must load even with several images present, but its sky
+        # coordinates must not be filled in using an arbitrary image's WCS.
+        wcs1 = self._make_tan_wcs(crval=(150.0, 30.0), crpix=(50.0, 50.0))
+        wcs2 = self._make_tan_wcs(crval=(10.0, -45.0), crpix=(500.0, 500.0))
+        self.image.load_image(NDData(data=data, wcs=wcs1), image_label="a")
+        self.image.load_image(NDData(data=data, wcs=wcs2), image_label="b")
+
+        self.image.load_catalog(Table(dict(x=[1.0], y=[2.0])), catalog_label="cat")
+
+        tab = self.image.get_catalog(catalog_label="cat")
+        assert not isinstance(tab["coord"], SkyCoord)
+
+    @pytest.mark.parametrize("load_order", [("nowcs", "withwcs"), ("withwcs", "nowcs")])
+    def test_get_viewport_default_uses_requested_image_wcs(self, data, wcs, load_order):
+        # Regression test for #93: the sky-vs-pixel default in get_viewport
+        # must be decided from the WCS of the *requested* image, not from
+        # the WCS of whichever image was loaded last.
+        for label in load_order:
+            use_wcs = wcs if label == "withwcs" else None
+            self.image.load_image(NDData(data=data, wcs=use_wcs), image_label=label)
+
+        vport = self.image.get_viewport(image_label="nowcs")
+        assert isinstance(vport["center"], tuple)
+        assert isinstance(vport["fov"], numbers.Real)
+
+        vport = self.image.get_viewport(image_label="withwcs")
+        assert isinstance(vport["center"], SkyCoord)
+        assert isinstance(vport["fov"], u.Quantity)
 
     def test_stretch(self, data):
         self.image.load_image(data, image_label="test")

--- a/src/astro_image_display_api/api_test.py
+++ b/src/astro_image_display_api/api_test.py
@@ -807,13 +807,13 @@ class ImageAPITest:
             x_colname="px", y_colname="py", skycoord_colname="sky", catalog_label="cat"
         )
         assert sorted(tab.colnames) == sorted(["px", "py", "sky"])
-        np.testing.assert_allclose(tab["px"], catalog["x"])
-        np.testing.assert_allclose(tab["py"], catalog["y"])
+        np.testing.assert_array_equal(tab["px"], catalog["x"])
+        np.testing.assert_array_equal(tab["py"], catalog["y"])
 
         # ...and get_catalog must return whatever column names are asked for.
         tab = self.image.get_catalog(catalog_label="cat")
         assert sorted(tab.colnames) == sorted(["x", "y", "coord"])
-        np.testing.assert_allclose(tab["x"], catalog["x"])
+        np.testing.assert_array_equal(tab["x"], catalog["x"])
 
     def test_get_catalog_renames_columns(self, catalog):
         # Regression test for #90: renaming the position columns to the
@@ -833,8 +833,8 @@ class ImageAPITest:
         assert "x" not in tab.colnames
         assert "y" not in tab.colnames
         assert "coord" not in tab.colnames
-        np.testing.assert_allclose(tab["xcen"], catalog["x"])
-        np.testing.assert_allclose(tab["ycen"], catalog["y"])
+        np.testing.assert_array_equal(tab["xcen"], catalog["x"])
+        np.testing.assert_array_equal(tab["ycen"], catalog["y"])
 
     def test_get_catalog_returns_copy(self, catalog):
         # Regression test for #90: the returned table must be a copy, so

--- a/src/astro_image_display_api/image_viewer_logic.py
+++ b/src/astro_image_display_api/image_viewer_logic.py
@@ -1,6 +1,6 @@
 import numbers
 import os
-from copy import copy, deepcopy
+from copy import copy
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -82,7 +82,6 @@ class ImageViewerLogic:
     """
 
     # some internal variable for keeping track of viewer state
-    _wcs: WCS | None = None
     _center: tuple[numbers.Real, numbers.Real] = (0.0, 0.0)
 
     def __post_init__(self):
@@ -324,10 +323,6 @@ class ImageViewerLogic:
             # Assume it is a 2D array
             self._load_array(file, image_label)
 
-        # This may eventually get pulled, but for now is needed to keep markers
-        # working with the new image.
-        self._wcs = self._images[image_label].wcs
-
     def get_image(
         self,
         image_label: str | None = None,
@@ -474,6 +469,50 @@ class ImageViewerLogic:
         p.write_text("This is a dummy file. The viewer does not save anything.")
 
     # Marker-related methods
+    def _catalog_conversion_wcs(self, conversion_required: bool) -> WCS | None:
+        """
+        Return the WCS to use for catalog pixel↔sky coordinate conversion.
+
+        A catalog cannot yet be associated with a particular image, so the
+        WCS is chosen with the same defaulting rule used for labels when no
+        label is given: if exactly one image is loaded, that image's WCS is
+        used. With no image loaded there is no WCS. With several images
+        loaded the choice is ambiguous, so if a conversion is actually
+        required an error is raised; otherwise no WCS is used, i.e. the
+        optional enrichment of the catalog with the coordinates that are
+        not in the table is skipped rather than done with an arbitrary
+        image's WCS.
+
+        Parameters
+        ----------
+        conversion_required : bool
+            Whether a pixel↔sky conversion is required to satisfy the
+            ``load_catalog`` call, as opposed to being merely opportunistic.
+
+        Returns
+        -------
+        `astropy.wcs.WCS` or None
+            The WCS of the single loaded image, or None.
+
+        Raises
+        ------
+        ValueError
+            If a conversion is required and several images are loaded.
+        """
+        match len(self._images):
+            case 0:
+                return None
+            case 1:
+                return list(self._images.values())[0].wcs
+            case _:
+                if conversion_required:
+                    raise ValueError(
+                        "Multiple image labels defined. Cannot determine "
+                        "which image's WCS to use to convert catalog "
+                        "coordinates."
+                    )
+                return None
+
     def load_catalog(
         self,
         table: Table,
@@ -495,10 +534,18 @@ class ImageViewerLogic:
         except KeyError:
             xy = None
 
-        to_add = deepcopy(table)
+        # A conversion is required, not just opportunistic, when the pixel
+        # columns must be computed from the sky coordinates or when sky
+        # coordinates were requested but are not in the table.
+        wcs = self._catalog_conversion_wcs(
+            conversion_required=(xy is None and coords is not None)
+            or (coords is None and use_skycoord)
+        )
+
+        to_add = table.copy()
         if xy is None:
-            if self._wcs is not None and coords is not None:
-                x, y = self._wcs.world_to_pixel(coords)
+            if wcs is not None and coords is not None:
+                x, y = wcs.world_to_pixel(coords)
                 to_add[x_colname] = x
                 to_add[y_colname] = y
                 xy = (x, y)
@@ -512,16 +559,22 @@ class ImageViewerLogic:
             )
 
         if coords is None:
-            if use_skycoord and self._wcs is None:
+            if use_skycoord and wcs is None:
                 raise ValueError(
                     "Cannot use sky coordinates without a SkyCoord column or WCS."
                 )
-            elif xy is not None and self._wcs is not None:
+            elif xy is not None and wcs is not None:
                 # If we have xy coordinates, convert them to sky coordinates
-                coords = self._wcs.pixel_to_world(xy[0], xy[1])
+                coords = wcs.pixel_to_world(xy[0], xy[1])
                 to_add[skycoord_colname] = coords
             else:
                 to_add[skycoord_colname] = None
+
+        # Store the position columns under canonical internal names so that
+        # get_catalog can return them under any requested names.
+        to_add.rename_columns(
+            [x_colname, y_colname, skycoord_colname], ["x", "y", "coord"]
+        )
 
         catalog_label = self._resolve_catalog_label(catalog_label, allow_new=True)
 
@@ -588,15 +641,14 @@ class ImageViewerLogic:
             # Nothing is loaded; return an empty table with the expected
             # columns rather than raising, so that "is there anything
             # here?" queries are easy to write.
-            result = Table(names=["x", "y", "coord"])
-        else:
-            catalog_label = self._resolve_catalog_label(catalog_label)
-            # Copy before renaming: rename_columns is in-place, and the
-            # table stored here is the actual registry entry, not a copy.
-            # Renaming it directly would permanently rename the columns of
-            # the stored catalog as a side effect of merely reading it.
-            result = self._catalogs[catalog_label].data.copy()
+            return Table(names=[x_colname, y_colname, skycoord_colname])
 
+        catalog_label = self._resolve_catalog_label(catalog_label)
+
+        # Return a copy so that modifying the returned table cannot corrupt
+        # the stored catalog, renamed from the canonical internal column
+        # names to the requested ones.
+        result = self._catalogs[catalog_label].data.copy()
         result.rename_columns(
             ["x", "y", "coord"], [x_colname, y_colname, skycoord_colname]
         )
@@ -694,11 +746,11 @@ class ImageViewerLogic:
         # then the return should be in world coordinates, otherwise it should
         # be in pixel coordinates.
         if sky_or_pixel is None:
-            if self._wcs is not None:
-                # Somebody set this to sky coordinates, so return sky coordinates
+            if viewport.wcs is not None:
+                # The requested image has a WCS, so return sky coordinates
                 sky_or_pixel = "sky"
             else:
-                # Somebody set this to pixel coordinates, so return pixel coordinates
+                # The requested image has no WCS, so return pixel coordinates
                 sky_or_pixel = "pixel"
 
         center = None

--- a/src/astro_image_display_api/image_viewer_logic.py
+++ b/src/astro_image_display_api/image_viewer_logic.py
@@ -473,16 +473,6 @@ class ImageViewerLogic:
         """
         Return the WCS to use for catalog pixel↔sky coordinate conversion.
 
-        A catalog cannot yet be associated with a particular image, so the
-        WCS is chosen with the same defaulting rule used for labels when no
-        label is given: if exactly one image is loaded, that image's WCS is
-        used. With no image loaded there is no WCS. With several images
-        loaded the choice is ambiguous, so if a conversion is actually
-        required an error is raised; otherwise no WCS is used, i.e. the
-        optional enrichment of the catalog with the coordinates that are
-        not in the table is skipped rather than done with an arbitrary
-        image's WCS.
-
         Parameters
         ----------
         conversion_required : bool
@@ -498,6 +488,17 @@ class ImageViewerLogic:
         ------
         ValueError
             If a conversion is required and several images are loaded.
+
+        Notes
+        -----
+        The WCS is chosen with the same defaulting rule used for labels
+        when no label is given: if exactly one image is loaded, that
+        image's WCS is used. With no image loaded there is no WCS. With
+        several images loaded the choice is ambiguous, so if a conversion
+        is actually required an error is raised; otherwise no WCS is used,
+        i.e. the optional enrichment of the catalog with the coordinates
+        that are not in the table is skipped rather than done with an
+        arbitrary image's WCS.
         """
         match len(self._images):
             case 0:


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on #116 and #117 — the diff includes their commits until they merge. Only the last commit (\`Fix get_catalog defects and use per-image WCS...\`) is new here.

This is the third of three PRs fixing state-model issues found in the July 2026 code review (#106 tracker).

### `get_catalog` fixes (#90)

- Catalog position columns are now stored under canonical internal names (`x`, `y`, `coord`), so a catalog loaded with custom column names is retrievable, and `get_catalog` renames a copy to whatever column names the caller requests. Previously the rename was a silent no-op (and a `KeyError` for custom-named catalogs).
- `load_catalog` copies the input with `Table.copy()` instead of `deepcopy()`; the deep copy left the table's column mapping out of sync after renames.
- `get_catalog` returns a **copy** of the stored table, so mutating the result can no longer corrupt viewer state, and the fresh-viewer empty table is built directly with the requested column names.

### Per-image WCS (#91)

The global `self._wcs`, which always pointed at the *last-loaded* image's WCS, is gone. `load_catalog` now picks the WCS for pixel↔sky conversion with the same defaulting rule already used for labels when none is given:

- exactly one image loaded → that image's WCS;
- no image loaded → no WCS (unchanged behavior);
- several images loaded → ambiguous: raises `ValueError` when a conversion is actually required (pixel columns must be computed from sky coordinates, or `use_skycoord=True` with no coordinate column), and otherwise skips the opportunistic enrichment of the missing coordinate column rather than filling it with an arbitrary image's WCS.

Once the displayed-image concept lands (#114), this rule can tighten to "the displayed image's WCS."

### `get_viewport` sky-vs-pixel default (#93)

`get_viewport` now decides its sky-vs-pixel default from the **requested** image's WCS (`viewport.wcs`) rather than global state, matching the documented per-image contract.

### Tests

Nine regression tests added to `api_test.py`, including two-image tests with different WCS verifying that catalog conversions refuse ambiguity instead of silently using the wrong WCS, that a loaded catalog's coordinates are not rewritten by later image loads, and that `get_viewport` picks the right image's WCS in both load orders. Full suite: 77 passed.

Closes #90
Closes #91
Closes #93

Generated by Claude Code at Matt Craig's direction.